### PR TITLE
add styles for standard plug-ins

### DIFF
--- a/themes/prism-base16-ateliersulphurpool.light.css
+++ b/themes/prism-base16-ateliersulphurpool.light.css
@@ -150,3 +150,23 @@ pre > code.highlight {
   outline: 0.4em solid #c94922;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: #dfe2f1;
+}
+
+.line-numbers-rows > span:before {
+  color: #979db4;
+}
+
+/* overrides color-values for the Line Highlight plugin
+ * http://prismjs.com/plugins/line-highlight/
+ */
+.line-highlight {
+  background: rgba(107, 115, 148, 0.2);
+  background: -webkit-linear-gradient(left, rgba(107, 115, 148, 0.2) 70%, rgba(107, 115, 148, 0));
+  background: linear-gradient(to right, rgba(107, 115, 148, 0.2) 70%, rgba(107, 115, 148, 0));
+}

--- a/themes/prism-duotone-dark.css
+++ b/themes/prism-duotone-dark.css
@@ -147,3 +147,22 @@ pre > code.highlight {
   outline-offset: .4em;
 }
 
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: #2c2937;
+}
+
+.line-numbers-rows > span:before {
+  color: #3c3949;
+}
+
+/* overrides color-values for the Line Highlight plugin
+* http://prismjs.com/plugins/line-highlight/
+*/
+.line-highlight {
+  background: rgba(224, 145, 66, 0.2);
+  background: -webkit-linear-gradient(left, rgba(224, 145, 66, 0.2) 70%, rgba(224, 145, 66, 0));
+  background: linear-gradient(to right, rgba(224, 145, 66, 0.2) 70%, rgba(224, 145, 66, 0));
+}

--- a/themes/prism-duotone-earth.css
+++ b/themes/prism-duotone-earth.css
@@ -146,3 +146,23 @@ pre > code.highlight {
   outline: .4em solid #816d5f;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: #35302b;
+}
+
+.line-numbers-rows > span:before {
+  color: #46403d;
+}
+
+/* overrides color-values for the Line Highlight plugin
+* http://prismjs.com/plugins/line-highlight/
+*/
+.line-highlight {
+  background: rgba(191, 160, 90, 0.2);
+  background: -webkit-linear-gradient(left, rgba(191, 160, 90, 0.2) 70%, rgba(191, 160, 90, 0));
+  background: linear-gradient(to right, rgba(191, 160, 90, 0.2) 70%, rgba(191, 160, 90, 0));
+}

--- a/themes/prism-duotone-forest.css
+++ b/themes/prism-duotone-forest.css
@@ -146,3 +146,23 @@ pre > code.highlight {
   outline: .4em solid #5c705c;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: #2c302c;
+}
+
+.line-numbers-rows > span:before {
+  color: #3b423b;
+}
+
+/* overrides color-values for the Line Highlight plugin
+* http://prismjs.com/plugins/line-highlight/
+*/
+.line-highlight {
+  background: rgba(162, 179, 77, 0.2);
+  background: -webkit-linear-gradient(left, rgba(162, 179, 77, 0.2) 70%, rgba(162, 179, 77, 0));
+  background: linear-gradient(to right, rgba(162, 179, 77, 0.2) 70%, rgba(162, 179, 77, 0));
+}

--- a/themes/prism-duotone-light.css
+++ b/themes/prism-duotone-light.css
@@ -146,3 +146,23 @@ pre > code.highlight {
   outline: .4em solid #896724;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: #ece8de;
+}
+
+.line-numbers-rows > span:before {
+  color: #cdc4b1;
+}
+
+/* overrides color-values for the Line Highlight plugin
+ * http://prismjs.com/plugins/line-highlight/
+ */
+.line-highlight {
+  background: rgba(45, 32, 6, 0.2);
+  background: -webkit-linear-gradient(left, rgba(45, 32, 6, 0.2) 70%, rgba(45, 32, 6, 0));
+  background: linear-gradient(to right, rgba(45, 32, 6, 0.2) 70%, rgba(45, 32, 6, 0));
+}

--- a/themes/prism-duotone-sea.css
+++ b/themes/prism-duotone-sea.css
@@ -146,3 +146,23 @@ pre > code.highlight {
   outline: .4em solid #34659d;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: #1f2932;
+}
+
+.line-numbers-rows > span:before {
+  color: #2c3847;
+}
+
+/* overrides color-values for the Line Highlight plugin
+* http://prismjs.com/plugins/line-highlight/
+*/
+.line-highlight {
+  background: rgba(10, 163, 112, 0.2);
+  background: -webkit-linear-gradient(left, rgba(10, 163, 112, 0.2) 70%, rgba(10, 163, 112, 0));
+  background: linear-gradient(to right, rgba(10, 163, 112, 0.2) 70%, rgba(10, 163, 112, 0));
+}

--- a/themes/prism-duotone-space.css
+++ b/themes/prism-duotone-space.css
@@ -146,3 +146,23 @@ pre > code.highlight {
   outline: .4em solid #7676f4;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: #262631;
+}
+
+.line-numbers-rows > span:before {
+  color: #393949;
+}
+
+/* overrides color-values for the Line Highlight plugin
+* http://prismjs.com/plugins/line-highlight/
+*/
+.line-highlight {
+  background: rgba(221, 103, 44, 0.2);
+  background: -webkit-linear-gradient(left, rgba(221, 103, 44, 0.2) 70%, rgba(221, 103, 44, 0));
+  background: linear-gradient(to right, rgba(221, 103, 44, 0.2) 70%, rgba(221, 103, 44, 0));
+}


### PR DESCRIPTION
Added a few declaration-blocks with theme matching color-values for Line-number and Line-highlighter plugins for Atelier Sulphurpool light, and the Duotone themes.

See also [this issue](https://github.com/PrismJS/prism-themes/issues/51)