### PR TITLE
Add .travis.yml and make tests exit ok

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js: stable
+script: npm test
+deploy:
+  provider: npm
+  email: lea@verou.me
+  api_key:
+    secure: TjRcXEr7Y/9KRJ4EOEQbd2Ij8hxKj8c/yOpEROy2lTYv6QH9x46nFDgZEE3VHfp/nnBUYpC47dRaSxiUj8H5rtkMNCZrREZu1n1zahmzP6dI6kCj+H3GiY7yw/Jhdx3uvQZHwknW2TJ/YRsLeQsmMSG2HnJobY9Zn4REX5ccP2E=
+  on:
+    tags: true
+    repo: PrismJS/prism-themes

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Addtional themes for the Prism syntax highlighting library.",
   "main": "README.md",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no tests required\" && exit 0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Uses the same encrypted key in `PrismJS/prism`.

Fixes #66.

Would love to get the latest version of prism-themes on npm. Not sure if it matters if we use the same key from Prism if it does, we can just change it here. Otherwise, just need to tag a new version and we're all set.