### PR TITLE
fix: Load Fira Mono font in Hopscotch theme over HTTPS

### DIFF
--- a/themes/prism-hopscotch.css
+++ b/themes/prism-hopscotch.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Fira+Mono);
+@import url(https://fonts.googleapis.com/css?family=Fira+Mono);
 /*
  * Hopscotch
  * by Jan T. Sott


### PR DESCRIPTION
Fixes #75 
See idleberg/Hopscotch#10