### PR TITLE
Line number fix

### DIFF
--- a/themes/prism-a11y-dark.css
+++ b/themes/prism-a11y-dark.css
@@ -9,6 +9,7 @@ pre[class*="language-"] {
 	color: #f8f8f2;
 	background: none;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-a11y-dark.css
+++ b/themes/prism-a11y-dark.css
@@ -9,7 +9,6 @@ pre[class*="language-"] {
 	color: #f8f8f2;
 	background: none;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-atom-dark.css
+++ b/themes/prism-atom-dark.css
@@ -8,7 +8,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: #c5c8c6;
 	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-    font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
+	font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;
@@ -63,7 +63,7 @@ pre[class*="language-"] {
 .token.property,
 .token.keyword,
 .token.tag {
-    color: #96CBFE;
+	color: #96CBFE;
 }
 
 .token.class-name {
@@ -73,7 +73,7 @@ pre[class*="language-"] {
 
 .token.boolean,
 .token.constant {
-    color: #99CC99;
+	color: #99CC99;
 }
 
 .token.symbol,
@@ -99,16 +99,16 @@ pre[class*="language-"] {
 }
 
 .token.operator {
-    color: #EDEDED;
+	color: #EDEDED;
 }
 
 .token.entity {
-    color: #FFFFB6;
-    /* text-decoration: underline; */
+	color: #FFFFB6;
+	/* text-decoration: underline; */
 }
 
 .token.url {
-    color: #96CBFE;
+	color: #96CBFE;
 }
 
 .language-css .token.string,
@@ -118,7 +118,7 @@ pre[class*="language-"] {
 
 .token.atrule,
 .token.attr-value {
-    color: #F9EE98;
+	color: #F9EE98;
 }
 
 .token.function {
@@ -126,7 +126,7 @@ pre[class*="language-"] {
 }
 
 .token.regex {
-    color: #E9C062;
+	color: #E9C062;
 }
 
 .token.important {

--- a/themes/prism-base16-ateliersulphurpool.light.css
+++ b/themes/prism-base16-ateliersulphurpool.light.css
@@ -9,96 +9,100 @@ Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/b
 */
 code[class*="language-"],
 pre[class*="language-"] {
-  font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-  font-size: 14px;
-  line-height: 1.375;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-  background: #f5f7ff;
-  color: #5e6687;
+	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+	font-size: 14px;
+	line-height: 1.375;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	background: #f5f7ff;
+	color: #5e6687;
+}
+
+pre > code[class*="language-"] {
+	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: #dfe2f1;
+	text-shadow: none;
+	background: #dfe2f1;
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: #dfe2f1;
+	text-shadow: none;
+	background: #dfe2f1;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
-  overflow: auto;
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
+	padding: .1em;
+	border-radius: .3em;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #898ea4;
+	color: #898ea4;
 }
 
 .token.punctuation {
-  color: #5e6687;
+	color: #5e6687;
 }
 
 .token.namespace {
-  opacity: .7;
+	opacity: .7;
 }
 
 .token.operator,
 .token.boolean,
 .token.number {
-  color: #c76b29;
+	color: #c76b29;
 }
 
 .token.property {
-  color: #c08b30;
+	color: #c08b30;
 }
 
 .token.tag {
-  color: #3d8fd1;
+	color: #3d8fd1;
 }
 
 .token.string {
-  color: #22a2c9;
+	color: #22a2c9;
 }
 
 .token.selector {
-  color: #6679cc;
+	color: #6679cc;
 }
 
 .token.attr-name {
-  color: #c76b29;
+	color: #c76b29;
 }
 
 .token.entity,
 .token.url,
 .language-css .token.string,
 .style .token.string {
-  color: #22a2c9;
+	color: #22a2c9;
 }
 
 .token.attr-value,
@@ -106,67 +110,67 @@ pre[class*="language-"] {
 .token.control,
 .token.directive,
 .token.unit {
-  color: #ac9739;
+	color: #ac9739;
 }
 
 .token.statement,
 .token.regex,
 .token.atrule {
-  color: #22a2c9;
+	color: #22a2c9;
 }
 
 .token.placeholder,
 .token.variable {
-  color: #3d8fd1;
+	color: #3d8fd1;
 }
 
 .token.deleted {
-  text-decoration: line-through;
+	text-decoration: line-through;
 }
 
 .token.inserted {
-  border-bottom: 1px dotted #202746;
-  text-decoration: none;
+	border-bottom: 1px dotted #202746;
+	text-decoration: none;
 }
 
 .token.italic {
-  font-style: italic;
+	font-style: italic;
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold;
+	font-weight: bold;
 }
 
 .token.important {
-  color: #c94922;
+	color: #c94922;
 }
 
 .token.entity {
-  cursor: help;
+	cursor: help;
 }
 
 pre > code.highlight {
-  outline: 0.4em solid #c94922;
-  outline-offset: .4em;
+	outline: 0.4em solid #c94922;
+	outline-offset: .4em;
 }
 
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
 .line-numbers .line-numbers-rows {
-  border-right-color: #dfe2f1;
+	border-right-color: #dfe2f1;
 }
 
 .line-numbers-rows > span:before {
-  color: #979db4;
+	color: #979db4;
 }
 
 /* overrides color-values for the Line Highlight plugin
  * http://prismjs.com/plugins/line-highlight/
  */
 .line-highlight {
-  background: rgba(107, 115, 148, 0.2);
-  background: -webkit-linear-gradient(left, rgba(107, 115, 148, 0.2) 70%, rgba(107, 115, 148, 0));
-  background: linear-gradient(to right, rgba(107, 115, 148, 0.2) 70%, rgba(107, 115, 148, 0));
+	background: rgba(107, 115, 148, 0.2);
+	background: -webkit-linear-gradient(left, rgba(107, 115, 148, 0.2) 70%, rgba(107, 115, 148, 0));
+	background: linear-gradient(to right, rgba(107, 115, 148, 0.2) 70%, rgba(107, 115, 148, 0));
 }

--- a/themes/prism-cb.css
+++ b/themes/prism-cb.css
@@ -1,13 +1,13 @@
 /*
- * Based on Plugin: Syntax Highlighter CB 
+ * Based on Plugin: Syntax Highlighter CB
  * Plugin URI: http://wp.tutsplus.com/tutorials/plugins/adding-a-syntax-highlighter-shortcode-using-prism-js
- * Description: Highlight your code snippets with an easy to use shortcode based on Lea Verou's Prism.js.  
- * Version: 1.0.0 
- * Author: c.bavota 
+ * Description: Highlight your code snippets with an easy to use shortcode based on Lea Verou's Prism.js.
+ * Version: 1.0.0
+ * Author: c.bavota
  * Author URI: http://bavotasan.comhttp://wp.tutsplus.com/tutorials/plugins/adding-a-syntax-highlighter-shortcode-using-prism-js/ */
 /* http://cbavota.bitbucket.org/syntax-highlighter/  */
 
-/* =====   ===== */ 
+/* =====   ===== */
 code[class*="language-"],
 pre[class*="language-"] {
 	color: #fff;
@@ -33,8 +33,8 @@ pre[class*="language-"] {
 }
 
 pre[class*="language-"] code {
-    float: left;
-    padding: 0 15px 0 0;
+	float: left;
+	padding: 0 15px 0 0;
 }
 
 pre[class*="language-"],
@@ -143,26 +143,26 @@ pre[data-line] {
 
 .line-highlight:before,
 .line-highlight[data-end]:after {
-    content: attr(data-start);
-    position: absolute;
-    top: .3em;
-    left: .6em;
-    min-width: 1em;
-    padding: 0 .5em;
-    background-color: rgba(255,255,255,.3);
-    color: #fff;
-    font: bold 65%/1.5 sans-serif;
-    text-align: center;
-    -moz-border-radius: 8px;
-    -webkit-border-radius: 8px;
-    border-radius: 8px;
-    text-shadow: none;
+	content: attr(data-start);
+	position: absolute;
+	top: .3em;
+	left: .6em;
+	min-width: 1em;
+	padding: 0 .5em;
+	background-color: rgba(255,255,255,.3);
+	color: #fff;
+	font: bold 65%/1.5 sans-serif;
+	text-align: center;
+	-moz-border-radius: 8px;
+	-webkit-border-radius: 8px;
+	border-radius: 8px;
+	text-shadow: none;
 }
 
 .line-highlight[data-end]:after {
-    content: attr(data-end);
-    top: auto;
-    bottom: .4em;
+	content: attr(data-end);
+	top: auto;
+	bottom: .4em;
 }
 
 /* for line numbers */
@@ -171,6 +171,6 @@ pre[data-line] {
 }
 
 .line-numbers-rows span {
-    padding-right: 10px;
-    border-right: 3px #d9d336 solid;
+	padding-right: 10px;
+	border-right: 3px #d9d336 solid;
 }

--- a/themes/prism-darcula.css
+++ b/themes/prism-darcula.css
@@ -31,14 +31,14 @@ pre[class*="language-"] {
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-    color: inherit;
-    background: rgba(33,66,131,.85);
+	color: inherit;
+	background: rgba(33,66,131,.85);
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
-    color: inherit;
-    background: rgba(33,66,131,.85);
+	color: inherit;
+	background: rgba(33,66,131,.85);
 }
 
 /* Code blocks */
@@ -77,26 +77,26 @@ pre[class*="language-"] {
 .token.operator,
 .token.punctuation,
 .token.attr-name {
-    color: #a9b7c6;
+	color: #a9b7c6;
 }
 
 .token.tag,
 .token.tag .punctuation,
 .token.doctype,
 .token.builtin {
-    color: #e8bf6a;
+	color: #e8bf6a;
 }
 
 .token.entity,
 .token.number,
 .token.symbol {
-    color: #6897bb;
+	color: #6897bb;
 }
 
 .token.property,
 .token.constant,
 .token.variable {
-    color: #9876aa;
+	color: #9876aa;
 }
 
 .token.string,
@@ -106,10 +106,10 @@ pre[class*="language-"] {
 
 .token.attr-value,
 .token.attr-value .punctuation {
-    color: #a5c261;
+	color: #a5c261;
 }
 .token.attr-value .punctuation:first-child {
-    color: #a9b7c6;
+	color: #a9b7c6;
 }
 
 .token.url {
@@ -122,7 +122,7 @@ pre[class*="language-"] {
 }
 
 .token.regex {
-    background: #364135;
+	background: #364135;
 }
 
 .token.bold {
@@ -134,11 +134,11 @@ pre[class*="language-"] {
 }
 
 .token.inserted {
-    background: #294436;
+	background: #294436;
 }
 
 .token.deleted {
-    background: #484a4a;
+	background: #484a4a;
 }
 
 /*code.language-css .token.punctuation {

--- a/themes/prism-dracula.css
+++ b/themes/prism-dracula.css
@@ -7,63 +7,63 @@
 
 code[class*="language-"],
 pre[class*="language-"] {
-  color: #f8f8f2;
-  background: none;
-  text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  word-wrap: normal;
-  line-height: 1.5;
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none; }
+	color: #f8f8f2;
+	background: none;
+	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none; }
 
 /* Code blocks */
 pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
-  overflow: auto;
-  border-radius: 0.3em; }
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+	border-radius: 0.3em; }
 
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
-  background: #282a36; }
+	background: #282a36; }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
-  white-space: normal; }
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal; }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #6272a4; }
+	color: #6272a4; }
 
 .token.punctuation {
-  color: #f8f8f2; }
+	color: #f8f8f2; }
 
 .namespace {
-  opacity: .7; }
+	opacity: .7; }
 
 .token.property,
 .token.tag,
 .token.constant,
 .token.symbol,
 .token.deleted {
-  color: #ff79c6; }
+	color: #ff79c6; }
 
 .token.boolean,
 .token.number {
-  color: #bd93f9; }
+	color: #bd93f9; }
 
 .token.selector,
 .token.attr-name,
@@ -71,7 +71,7 @@ pre[class*="language-"] {
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #50fa7b; }
+	color: #50fa7b; }
 
 .token.operator,
 .token.entity,
@@ -79,28 +79,28 @@ pre[class*="language-"] {
 .language-css .token.string,
 .style .token.string,
 .token.variable {
-  color: #f8f8f2; }
+	color: #f8f8f2; }
 
 .token.atrule,
 .token.attr-value,
 .token.function,
 .token.class-name {
-  color: #f1fa8c; }
+	color: #f1fa8c; }
 
 .token.keyword {
-  color: #8be9fd; }
+	color: #8be9fd; }
 
 .token.regex,
 .token.important {
-  color: #ffb86c; }
+	color: #ffb86c; }
 
 .token.important,
 .token.bold {
-  font-weight: bold; }
+	font-weight: bold; }
 
 .token.italic {
-  font-style: italic; }
+	font-style: italic; }
 
 .token.entity {
-  cursor: help; }
+	cursor: help; }
 

--- a/themes/prism-duotone-dark.css
+++ b/themes/prism-duotone-dark.css
@@ -8,87 +8,91 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 
 code[class*="language-"],
 pre[class*="language-"] {
-  font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-  font-size: 14px;
-  line-height: 1.375;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
+	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+	font-size: 14px;
+	line-height: 1.375;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
 
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
 
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-  background: #2a2734;
-  color: #9a86fd;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	background: #2a2734;
+	color: #9a86fd;
+}
+
+pre > code[class*="language-"] {
+	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: #6a51e6;
+	text-shadow: none;
+	background: #6a51e6;
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: #6a51e6;
+	text-shadow: none;
+	background: #6a51e6;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
-  overflow: auto;
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
+	padding: .1em;
+	border-radius: .3em;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #6c6783;
+	color: #6c6783;
 }
 
 .token.punctuation {
-  color: #6c6783;
+	color: #6c6783;
 }
 
 .token.namespace {
-  opacity: .7;
+	opacity: .7;
 }
 
 .token.tag,
 .token.operator,
 .token.number {
-  color: #e09142;
+	color: #e09142;
 }
 
 .token.property,
 .token.function {
-  color: #9a86fd;
+	color: #9a86fd;
 }
 
 .token.tag-id,
 .token.selector,
 .token.atrule-id {
-  color: #eeebff;
+	color: #eeebff;
 }
 
 code.language-javascript,
 .token.attr-name {
-  color: #c4b9fe;
+	color: #c4b9fe;
 }
 
 code.language-css,
@@ -108,61 +112,61 @@ code.language-scss,
 .token.statement,
 .token.regex,
 .token.atrule {
-  color: #ffcc99;
+	color: #ffcc99;
 }
 
 .token.placeholder,
 .token.variable {
-  color: #ffcc99;
+	color: #ffcc99;
 }
 
 .token.deleted {
-  text-decoration: line-through;
+	text-decoration: line-through;
 }
 
 .token.inserted {
-  border-bottom: 1px dotted #eeebff;
-  text-decoration: none;
+	border-bottom: 1px dotted #eeebff;
+	text-decoration: none;
 }
 
 .token.italic {
-  font-style: italic;
+	font-style: italic;
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold;
+	font-weight: bold;
 }
 
 .token.important {
-  color: #c4b9fe;
+	color: #c4b9fe;
 }
 
 .token.entity {
-  cursor: help;
+	cursor: help;
 }
 
 pre > code.highlight {
-  outline: .4em solid #8a75f5;
-  outline-offset: .4em;
+	outline: .4em solid #8a75f5;
+	outline-offset: .4em;
 }
 
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
 .line-numbers .line-numbers-rows {
-  border-right-color: #2c2937;
+	border-right-color: #2c2937;
 }
 
 .line-numbers-rows > span:before {
-  color: #3c3949;
+	color: #3c3949;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
 .line-highlight {
-  background: rgba(224, 145, 66, 0.2);
-  background: -webkit-linear-gradient(left, rgba(224, 145, 66, 0.2) 70%, rgba(224, 145, 66, 0));
-  background: linear-gradient(to right, rgba(224, 145, 66, 0.2) 70%, rgba(224, 145, 66, 0));
+	background: rgba(224, 145, 66, 0.2);
+	background: -webkit-linear-gradient(left, rgba(224, 145, 66, 0.2) 70%, rgba(224, 145, 66, 0));
+	background: linear-gradient(to right, rgba(224, 145, 66, 0.2) 70%, rgba(224, 145, 66, 0));
 }

--- a/themes/prism-duotone-earth.css
+++ b/themes/prism-duotone-earth.css
@@ -8,87 +8,91 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 
 code[class*="language-"],
 pre[class*="language-"] {
-  font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-  font-size: 14px;
-  line-height: 1.375;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
+	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+	font-size: 14px;
+	line-height: 1.375;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
 
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
 
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-  background: #322d29;
-  color: #88786d;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	background: #322d29;
+	color: #88786d;
+}
+
+pre > code[class*="language-"] {
+	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: #6f5849;
+	text-shadow: none;
+	background: #6f5849;
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: #6f5849;
+	text-shadow: none;
+	background: #6f5849;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
-  overflow: auto;
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
+	padding: .1em;
+	border-radius: .3em;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #6a5f58;
+	color: #6a5f58;
 }
 
 .token.punctuation {
-  color: #6a5f58;
+	color: #6a5f58;
 }
 
 .token.namespace {
-  opacity: .7;
+	opacity: .7;
 }
 
 .token.tag,
 .token.operator,
 .token.number {
-  color: #bfa05a;
+	color: #bfa05a;
 }
 
 .token.property,
 .token.function {
-  color: #88786d;
+	color: #88786d;
 }
 
 .token.tag-id,
 .token.selector,
 .token.atrule-id {
-  color: #fff3eb;
+	color: #fff3eb;
 }
 
 code.language-javascript,
 .token.attr-name {
-  color: #a48774;
+	color: #a48774;
 }
 
 code.language-css,
@@ -108,61 +112,61 @@ code.language-scss,
 .token.statement,
 .token.regex,
 .token.atrule {
-  color: #fcc440;
+	color: #fcc440;
 }
 
 .token.placeholder,
 .token.variable {
-  color: #fcc440;
+	color: #fcc440;
 }
 
 .token.deleted {
-  text-decoration: line-through;
+	text-decoration: line-through;
 }
 
 .token.inserted {
-  border-bottom: 1px dotted #fff3eb;
-  text-decoration: none;
+	border-bottom: 1px dotted #fff3eb;
+	text-decoration: none;
 }
 
 .token.italic {
-  font-style: italic;
+	font-style: italic;
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold;
+	font-weight: bold;
 }
 
 .token.important {
-  color: #a48774;
+	color: #a48774;
 }
 
 .token.entity {
-  cursor: help;
+	cursor: help;
 }
 
 pre > code.highlight {
-  outline: .4em solid #816d5f;
-  outline-offset: .4em;
+	outline: .4em solid #816d5f;
+	outline-offset: .4em;
 }
 
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
 .line-numbers .line-numbers-rows {
-  border-right-color: #35302b;
+	border-right-color: #35302b;
 }
 
 .line-numbers-rows > span:before {
-  color: #46403d;
+	color: #46403d;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
 .line-highlight {
-  background: rgba(191, 160, 90, 0.2);
-  background: -webkit-linear-gradient(left, rgba(191, 160, 90, 0.2) 70%, rgba(191, 160, 90, 0));
-  background: linear-gradient(to right, rgba(191, 160, 90, 0.2) 70%, rgba(191, 160, 90, 0));
+	background: rgba(191, 160, 90, 0.2);
+	background: -webkit-linear-gradient(left, rgba(191, 160, 90, 0.2) 70%, rgba(191, 160, 90, 0));
+	background: linear-gradient(to right, rgba(191, 160, 90, 0.2) 70%, rgba(191, 160, 90, 0));
 }

--- a/themes/prism-duotone-forest.css
+++ b/themes/prism-duotone-forest.css
@@ -8,87 +8,91 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 
 code[class*="language-"],
 pre[class*="language-"] {
-  font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-  font-size: 14px;
-  line-height: 1.375;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
+	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+	font-size: 14px;
+	line-height: 1.375;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
 
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
 
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-  background: #2a2d2a;
-  color: #687d68;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	background: #2a2d2a;
+	color: #687d68;
+}
+
+pre > code[class*="language-"] {
+	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: #435643;
+	text-shadow: none;
+	background: #435643;
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: #435643;
+	text-shadow: none;
+	background: #435643;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
-  overflow: auto;
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
+	padding: .1em;
+	border-radius: .3em;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #535f53;
+	color: #535f53;
 }
 
 .token.punctuation {
-  color: #535f53;
+	color: #535f53;
 }
 
 .token.namespace {
-  opacity: .7;
+	opacity: .7;
 }
 
 .token.tag,
 .token.operator,
 .token.number {
-  color: #a2b34d;
+	color: #a2b34d;
 }
 
 .token.property,
 .token.function {
-  color: #687d68;
+	color: #687d68;
 }
 
 .token.tag-id,
 .token.selector,
 .token.atrule-id {
-  color: #f0fff0;
+	color: #f0fff0;
 }
 
 code.language-javascript,
 .token.attr-name {
-  color: #b3d6b3;
+	color: #b3d6b3;
 }
 
 code.language-css,
@@ -108,61 +112,61 @@ code.language-scss,
 .token.statement,
 .token.regex,
 .token.atrule {
-  color: #e5fb79;
+	color: #e5fb79;
 }
 
 .token.placeholder,
 .token.variable {
-  color: #e5fb79;
+	color: #e5fb79;
 }
 
 .token.deleted {
-  text-decoration: line-through;
+	text-decoration: line-through;
 }
 
 .token.inserted {
-  border-bottom: 1px dotted #f0fff0;
-  text-decoration: none;
+	border-bottom: 1px dotted #f0fff0;
+	text-decoration: none;
 }
 
 .token.italic {
-  font-style: italic;
+	font-style: italic;
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold;
+	font-weight: bold;
 }
 
 .token.important {
-  color: #b3d6b3;
+	color: #b3d6b3;
 }
 
 .token.entity {
-  cursor: help;
+	cursor: help;
 }
 
 pre > code.highlight {
-  outline: .4em solid #5c705c;
-  outline-offset: .4em;
+	outline: .4em solid #5c705c;
+	outline-offset: .4em;
 }
 
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
 .line-numbers .line-numbers-rows {
-  border-right-color: #2c302c;
+	border-right-color: #2c302c;
 }
 
 .line-numbers-rows > span:before {
-  color: #3b423b;
+	color: #3b423b;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
 .line-highlight {
-  background: rgba(162, 179, 77, 0.2);
-  background: -webkit-linear-gradient(left, rgba(162, 179, 77, 0.2) 70%, rgba(162, 179, 77, 0));
-  background: linear-gradient(to right, rgba(162, 179, 77, 0.2) 70%, rgba(162, 179, 77, 0));
+	background: rgba(162, 179, 77, 0.2);
+	background: -webkit-linear-gradient(left, rgba(162, 179, 77, 0.2) 70%, rgba(162, 179, 77, 0));
+	background: linear-gradient(to right, rgba(162, 179, 77, 0.2) 70%, rgba(162, 179, 77, 0));
 }

--- a/themes/prism-duotone-light.css
+++ b/themes/prism-duotone-light.css
@@ -8,87 +8,91 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 
 code[class*="language-"],
 pre[class*="language-"] {
-  font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-  font-size: 14px;
-  line-height: 1.375;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
+	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+	font-size: 14px;
+	line-height: 1.375;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
 
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
 
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-  background: #faf8f5;
-  color: #728fcb;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	background: #faf8f5;
+	color: #728fcb;
+}
+
+pre > code[class*="language-"] {
+	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: #faf8f5;
+	text-shadow: none;
+	background: #faf8f5;
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: #faf8f5;
+	text-shadow: none;
+	background: #faf8f5;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
-  overflow: auto;
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
+	padding: .1em;
+	border-radius: .3em;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #b6ad9a;
+	color: #b6ad9a;
 }
 
 .token.punctuation {
-  color: #b6ad9a;
+	color: #b6ad9a;
 }
 
 .token.namespace {
-  opacity: .7;
+	opacity: .7;
 }
 
 .token.tag,
 .token.operator,
 .token.number {
-  color: #063289;
+	color: #063289;
 }
 
 .token.property,
 .token.function {
-  color: #b29762;
+	color: #b29762;
 }
 
 .token.tag-id,
 .token.selector,
 .token.atrule-id {
-  color: #2d2006;
+	color: #2d2006;
 }
 
 code.language-javascript,
 .token.attr-name {
-  color: #896724;
+	color: #896724;
 }
 
 code.language-css,
@@ -108,61 +112,61 @@ code.language-scss,
 .token.statement,
 .token.regex,
 .token.atrule {
-  color: #728fcb;
+	color: #728fcb;
 }
 
 .token.placeholder,
 .token.variable {
-  color: #93abdc;
+	color: #93abdc;
 }
 
 .token.deleted {
-  text-decoration: line-through;
+	text-decoration: line-through;
 }
 
 .token.inserted {
-  border-bottom: 1px dotted #2d2006;
-  text-decoration: none;
+	border-bottom: 1px dotted #2d2006;
+	text-decoration: none;
 }
 
 .token.italic {
-  font-style: italic;
+	font-style: italic;
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold;
+	font-weight: bold;
 }
 
 .token.important {
-  color: #896724;
+	color: #896724;
 }
 
 .token.entity {
-  cursor: help;
+	cursor: help;
 }
 
 pre > code.highlight {
-  outline: .4em solid #896724;
-  outline-offset: .4em;
+	outline: .4em solid #896724;
+	outline-offset: .4em;
 }
 
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
 .line-numbers .line-numbers-rows {
-  border-right-color: #ece8de;
+	border-right-color: #ece8de;
 }
 
 .line-numbers-rows > span:before {
-  color: #cdc4b1;
+	color: #cdc4b1;
 }
 
 /* overrides color-values for the Line Highlight plugin
  * http://prismjs.com/plugins/line-highlight/
  */
 .line-highlight {
-  background: rgba(45, 32, 6, 0.2);
-  background: -webkit-linear-gradient(left, rgba(45, 32, 6, 0.2) 70%, rgba(45, 32, 6, 0));
-  background: linear-gradient(to right, rgba(45, 32, 6, 0.2) 70%, rgba(45, 32, 6, 0));
+	background: rgba(45, 32, 6, 0.2);
+	background: -webkit-linear-gradient(left, rgba(45, 32, 6, 0.2) 70%, rgba(45, 32, 6, 0));
+	background: linear-gradient(to right, rgba(45, 32, 6, 0.2) 70%, rgba(45, 32, 6, 0));
 }

--- a/themes/prism-duotone-sea.css
+++ b/themes/prism-duotone-sea.css
@@ -8,87 +8,91 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 
 code[class*="language-"],
 pre[class*="language-"] {
-  font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-  font-size: 14px;
-  line-height: 1.375;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
+	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+	font-size: 14px;
+	line-height: 1.375;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
 
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
 
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-  background: #1d262f;
-  color: #57718e;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	background: #1d262f;
+	color: #57718e;
+}
+
+pre > code[class*="language-"] {
+	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: #004a9e;
+	text-shadow: none;
+	background: #004a9e;
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: #004a9e;
+	text-shadow: none;
+	background: #004a9e;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
-  overflow: auto;
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
+	padding: .1em;
+	border-radius: .3em;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #4a5f78;
+	color: #4a5f78;
 }
 
 .token.punctuation {
-  color: #4a5f78;
+	color: #4a5f78;
 }
 
 .token.namespace {
-  opacity: .7;
+	opacity: .7;
 }
 
 .token.tag,
 .token.operator,
 .token.number {
-  color: #0aa370;
+	color: #0aa370;
 }
 
 .token.property,
 .token.function {
-  color: #57718e;
+	color: #57718e;
 }
 
 .token.tag-id,
 .token.selector,
 .token.atrule-id {
-  color: #ebf4ff;
+	color: #ebf4ff;
 }
 
 code.language-javascript,
 .token.attr-name {
-  color: #7eb6f6;
+	color: #7eb6f6;
 }
 
 code.language-css,
@@ -108,61 +112,61 @@ code.language-scss,
 .token.statement,
 .token.regex,
 .token.atrule {
-  color: #47ebb4;
+	color: #47ebb4;
 }
 
 .token.placeholder,
 .token.variable {
-  color: #47ebb4;
+	color: #47ebb4;
 }
 
 .token.deleted {
-  text-decoration: line-through;
+	text-decoration: line-through;
 }
 
 .token.inserted {
-  border-bottom: 1px dotted #ebf4ff;
-  text-decoration: none;
+	border-bottom: 1px dotted #ebf4ff;
+	text-decoration: none;
 }
 
 .token.italic {
-  font-style: italic;
+	font-style: italic;
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold;
+	font-weight: bold;
 }
 
 .token.important {
-  color: #7eb6f6;
+	color: #7eb6f6;
 }
 
 .token.entity {
-  cursor: help;
+	cursor: help;
 }
 
 pre > code.highlight {
-  outline: .4em solid #34659d;
-  outline-offset: .4em;
+	outline: .4em solid #34659d;
+	outline-offset: .4em;
 }
 
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
 .line-numbers .line-numbers-rows {
-  border-right-color: #1f2932;
+	border-right-color: #1f2932;
 }
 
 .line-numbers-rows > span:before {
-  color: #2c3847;
+	color: #2c3847;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
 .line-highlight {
-  background: rgba(10, 163, 112, 0.2);
-  background: -webkit-linear-gradient(left, rgba(10, 163, 112, 0.2) 70%, rgba(10, 163, 112, 0));
-  background: linear-gradient(to right, rgba(10, 163, 112, 0.2) 70%, rgba(10, 163, 112, 0));
+	background: rgba(10, 163, 112, 0.2);
+	background: -webkit-linear-gradient(left, rgba(10, 163, 112, 0.2) 70%, rgba(10, 163, 112, 0));
+	background: linear-gradient(to right, rgba(10, 163, 112, 0.2) 70%, rgba(10, 163, 112, 0));
 }

--- a/themes/prism-duotone-space.css
+++ b/themes/prism-duotone-space.css
@@ -8,87 +8,91 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 
 code[class*="language-"],
 pre[class*="language-"] {
-  font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-  font-size: 14px;
-  line-height: 1.375;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
+	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+	font-size: 14px;
+	line-height: 1.375;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
 
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
 
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-  background: #24242e;
-  color: #767693;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	background: #24242e;
+	color: #767693;
+}
+
+pre > code[class*="language-"] {
+	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: #5151e6;
+	text-shadow: none;
+	background: #5151e6;
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: #5151e6;
+	text-shadow: none;
+	background: #5151e6;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
-  overflow: auto;
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
+	padding: .1em;
+	border-radius: .3em;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #5b5b76;
+	color: #5b5b76;
 }
 
 .token.punctuation {
-  color: #5b5b76;
+	color: #5b5b76;
 }
 
 .token.namespace {
-  opacity: .7;
+	opacity: .7;
 }
 
 .token.tag,
 .token.operator,
 .token.number {
-  color: #dd672c;
+	color: #dd672c;
 }
 
 .token.property,
 .token.function {
-  color: #767693;
+	color: #767693;
 }
 
 .token.tag-id,
 .token.selector,
 .token.atrule-id {
-  color: #ebebff;
+	color: #ebebff;
 }
 
 code.language-javascript,
 .token.attr-name {
-  color: #aaaaca;
+	color: #aaaaca;
 }
 
 code.language-css,
@@ -108,61 +112,61 @@ code.language-scss,
 .token.statement,
 .token.regex,
 .token.atrule {
-  color: #fe8c52;
+	color: #fe8c52;
 }
 
 .token.placeholder,
 .token.variable {
-  color: #fe8c52;
+	color: #fe8c52;
 }
 
 .token.deleted {
-  text-decoration: line-through;
+	text-decoration: line-through;
 }
 
 .token.inserted {
-  border-bottom: 1px dotted #ebebff;
-  text-decoration: none;
+	border-bottom: 1px dotted #ebebff;
+	text-decoration: none;
 }
 
 .token.italic {
-  font-style: italic;
+	font-style: italic;
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold;
+	font-weight: bold;
 }
 
 .token.important {
-  color: #aaaaca;
+	color: #aaaaca;
 }
 
 .token.entity {
-  cursor: help;
+	cursor: help;
 }
 
 pre > code.highlight {
-  outline: .4em solid #7676f4;
-  outline-offset: .4em;
+	outline: .4em solid #7676f4;
+	outline-offset: .4em;
 }
 
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
 .line-numbers .line-numbers-rows {
-  border-right-color: #262631;
+	border-right-color: #262631;
 }
 
 .line-numbers-rows > span:before {
-  color: #393949;
+	color: #393949;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
 .line-highlight {
-  background: rgba(221, 103, 44, 0.2);
-  background: -webkit-linear-gradient(left, rgba(221, 103, 44, 0.2) 70%, rgba(221, 103, 44, 0));
-  background: linear-gradient(to right, rgba(221, 103, 44, 0.2) 70%, rgba(221, 103, 44, 0));
+	background: rgba(221, 103, 44, 0.2);
+	background: -webkit-linear-gradient(left, rgba(221, 103, 44, 0.2) 70%, rgba(221, 103, 44, 0));
+	background: linear-gradient(to right, rgba(221, 103, 44, 0.2) 70%, rgba(221, 103, 44, 0));
 }

--- a/themes/prism-ghcolors.css
+++ b/themes/prism-ghcolors.css
@@ -5,75 +5,75 @@
 
 code[class*="language-"],
 pre[class*="language-"] {
-    color: #393A34;
-    font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
-    direction: ltr;
-    text-align: left;
-    white-space: pre;
-    word-spacing: normal;
-    word-break: normal;
-    font-size: 0.95em;
-    line-height: 1.2em;
+	color: #393A34;
+	font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	font-size: .9em;
+	line-height: 1.2em;
 
-    -moz-tab-size: 4;
-    -o-tab-size: 4;
-    tab-size: 4;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
 
-    -webkit-hyphens: none;
-    -moz-hyphens: none;
-    -ms-hyphens: none;
-    hyphens: none;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+pre > code[class*="language-"] {
+	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-    background: #b3d4fc;
+	background: #b3d4fc;
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
-    background: #b3d4fc;
+	background: #b3d4fc;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-    padding: 1em;
-    margin: .5em 0;
-    overflow: auto;
-    border: 1px solid #dddddd;
-    background-color: white;
-}
-
-:not(pre) > code[class*="language-"],
-pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+	border: 1px solid #dddddd;
+	background-color: white;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-    padding: .2em;
-    padding-top: 1px; padding-bottom: 1px;
-    background: #f8f8f8;
-    border: 1px solid #dddddd;
+	padding: .2em;
+	padding-top: 1px; padding-bottom: 1px;
+	background: #f8f8f8;
+	border: 1px solid #dddddd;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-    color: #999988; font-style: italic;
+	color: #999988; font-style: italic;
 }
 
 .token.namespace {
-    opacity: .7;
+	opacity: .7;
 }
 
 .token.string,
 .token.attr-value {
-    color: #e3116c;
+	color: #e3116c;
 }
 .token.punctuation,
 .token.operator {
-    color: #393A34; /* no highlight */
+	color: #393A34; /* no highlight */
 }
 
 .token.entity,
@@ -86,34 +86,34 @@ pre[class*="language-"] {
 .token.property,
 .token.regex,
 .token.inserted {
-    color: #36acaa;
+	color: #36acaa;
 }
 
 .token.atrule,
 .token.keyword,
 .token.attr-name,
 .language-autohotkey .token.selector {
-    color: #00a4db;
+	color: #00a4db;
 }
 
 .token.function,
 .token.deleted,
 .language-autohotkey .token.tag {
-    color: #9a050f;
+	color: #9a050f;
 }
 
 .token.tag,
 .token.selector,
 .language-autohotkey .token.keyword {
-    color: #00009f;
+	color: #00009f;
 }
 
 .token.important,
 .token.function,
 .token.bold {
-    font-weight: bold;
+	font-weight: bold;
 }
 
 .token.italic {
-    font-style: italic;
+	font-style: italic;
 }

--- a/themes/prism-hopscotch.css
+++ b/themes/prism-hopscotch.css
@@ -5,88 +5,92 @@
  * https://github.com/idleberg/Hopscotch
  *
  * This work is licensed under the Creative Commons CC0 1.0 Universal License
- */ 
- 
+ */
+
 code[class*="language-"],
 pre[class*="language-"] {
-  color: #ffffff;
-  font-family: "Fira Mono", Menlo, Monaco, "Lucida Console","Courier New", Courier, monospace;
-  font-size: 16px;
-  line-height: 1.375;
-  direction: ltr;
-  text-align: left;
-  word-spacing: normal;
+	color: #ffffff;
+	font-family: "Fira Mono", Menlo, Monaco, "Lucida Console","Courier New", Courier, monospace;
+	font-size: 16px;
+	line-height: 1.375;
+	direction: ltr;
+	text-align: left;
+	word-spacing: normal;
 
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
 
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none; 
-  white-space: pre; 
-  white-space: pre-wrap; 
-  word-break: break-all;
-  word-wrap: break-word; 
-  background: #322931; 
-  color: #b9b5b8;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	white-space: pre;
+	white-space: pre-wrap;
+	word-break: break-all;
+	word-wrap: break-word;
+	background: #322931;
+	color: #b9b5b8;
+}
+
+pre > code[class*="language-"] {
+	font-size: 1em;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
-  overflow: auto; 
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
+	padding: .1em;
+	border-radius: .3em;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #797379;
+	color: #797379;
 }
 
 .token.punctuation {
-  color: #b9b5b8;
+	color: #b9b5b8;
 }
 
 .namespace {
-  opacity: .7;
+	opacity: .7;
 }
 
 .token.null,
 .token.operator,
 .token.boolean,
 .token.number {
-  color: #fd8b19;
-} 
-.token.property { 
-  color: #fdcc59;
+	color: #fd8b19;
 }
-.token.tag { 
-  color: #1290bf;
-} 
+.token.property {
+	color: #fdcc59;
+}
+.token.tag {
+	color: #1290bf;
+}
 .token.string {
-  color: #149b93;
-} 
-.token.selector { 
-  color: #c85e7c;
+	color: #149b93;
 }
-.token.attr-name { 
-  color: #fd8b19;
-} 
+.token.selector {
+	color: #c85e7c;
+}
+.token.attr-name {
+	color: #fd8b19;
+}
 .token.entity,
-.token.url, 
+.token.url,
 .language-css .token.string,
 .style .token.string {
-  color: #149b93;
+	color: #149b93;
 }
 
 .token.attr-value,
@@ -94,31 +98,31 @@ pre[class*="language-"] {
 .token.control,
 .token.directive,
 .token.unit {
-  color: #8fc13e;
-} 
+	color: #8fc13e;
+}
 
 .token.statement,
-.token.regex, 
-.token.atrule { 
-  color: #149b93;
+.token.regex,
+.token.atrule {
+	color: #149b93;
 }
 
 .token.placeholder,
 .token.variable {
-  color: #1290bf;
-} 
+	color: #1290bf;
+}
 
 .token.important {
-  color: #dd464c;
-  font-weight: bold;
-} 
+	color: #dd464c;
+	font-weight: bold;
+}
 
 .token.entity {
-  cursor: help;
-} 
+	cursor: help;
+}
 
 pre > code.highlight {
-  outline: .4em solid red;
-  outline-offset: .4em;
-} 
+	outline: .4em solid red;
+	outline-offset: .4em;
+}
 

--- a/themes/prism-pojoaque.css
+++ b/themes/prism-pojoaque.css
@@ -7,85 +7,89 @@
 
 code[class*="language-"],
 pre[class*="language-"] {
-    -moz-tab-size: 4;
-    -o-tab-size: 4;
-    tab-size: 4;
-    -webkit-hyphens: none;
-    -moz-hyphens: none;
-    -ms-hyphens: none;
-    hyphens: none;
-    white-space: pre;
-    white-space: pre-wrap;
-    word-break: break-all;
-    word-wrap: break-word;
-    font-family: Menlo, Monaco, "Courier New", monospace;
-    font-size: 15px;
-    line-height: 1.5;
-    color: #dccf8f;
-    text-shadow: 0;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	white-space: pre;
+	white-space: pre-wrap;
+	word-break: break-all;
+	word-wrap: break-word;
+	font-family: Menlo, Monaco, "Courier New", monospace;
+	font-size: 15px;
+	line-height: 1.5;
+	color: #dccf8f;
+	text-shadow: 0;
+}
+
+pre > code[class*="language-"] {
+	font-size: 1em;
 }
 
 pre[class*="language-"],
 :not(pre) > code[class*="language-"] {
-    border-radius: 5px;
-    border: 1px solid #000;
-    color: #DCCF8F;
-    background: #181914 url('data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD/7AARRHVja3kAAQAEAAAAMAAA/+4ADkFkb2JlAGTAAAAAAf/bAIQACQYGBgcGCQcHCQ0IBwgNDwsJCQsPEQ4ODw4OERENDg4ODg0RERQUFhQUERoaHBwaGiYmJiYmKysrKysrKysrKwEJCAgJCgkMCgoMDwwODA8TDg4ODhMVDg4PDg4VGhMRERERExoXGhYWFhoXHR0aGh0dJCQjJCQrKysrKysrKysr/8AAEQgAjACMAwEiAAIRAQMRAf/EAF4AAQEBAAAAAAAAAAAAAAAAAAABBwEBAQAAAAAAAAAAAAAAAAAAAAIQAAEDAwIHAQEAAAAAAAAAAADwAREhYaExkUFRcYGxwdHh8REBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AyGFEjHaBS2fDDs2zkhKmBKktb7km+ZwwCnXPkLVmCTMItj6AXFxRS465/BTnkAJvkLkJe+7AKKoi2AtRS2zuAWsCb5GOlBN8gKfmuGHZ8MFqIth3ALmFoFwbwKWyAlTAp17uKqBvgBD8sM4fTjhvAhkzhaRkBMKBrfs7jGPIpzy7gFrAqnC0C0gB0EWwBDW2cBVQwm+QtPpa3wBO3sVvszCnLAhkzgL5/RLf13cLQd8/AGlu0Cb5HTx9KuAEieGJEdcehS3eRTp2ATdt3CpIm+QtZwAhROXFeb7swp/ahaM3kBE/jSIUBc/AWrgBN8uNFAl+b7sAXFxFn2YLUU5Ns7gFX8C4ib+hN8gFWXwK3bZglxEJm+gKdciLPsFV/TClsgJUwKJ5FVA7tvIFrfZhVfGJDcsCKaYgAqv6YRbE+RWOWBtu7+AL3yRalXLyKqAIIfk+zARbDgFyEsncYwJvlgFRW+GEWntIi2P0BooyFxcNr8Ep3+ANLbMO+QyhvbiqdgC0kVvgUUiLYgBS2QtPbiVI1/sgOmG9uO+Y8DW+7jS2zAOnj6O2BndwuIAUtkdRN8gFoK3wwXMQyZwHVbClsuNLd4E3yAUR6FVDBR+BafQGt93LVMxJTv8ABts4CVLhcfYWsCb5kC9/BHdU8CLYFY5bMAd+eX9MGthhpbA1vu4B7+RKkaW2Yq4AQtVBBFsAJU/AuIXBhN8gGWnstefhiZyWvLAEnbYS1uzSFP6Jvn4Baxx70JKkQojLib5AVTey1jjgkKJGO0AKWyOm7N7cSpgSpAdPH0Tfd/gp1z5C1ZgKqN9J2wFxcUUuAFLZAm+QC0Fb4YUVRFsAOvj4KW2dwtYE3yAWk/wS/PLMKfmuGHZ8MAXF/Ja32Yi5haAKWz4Ydm2cSpgU693Atb7km+Zwwh+WGcPpxw3gAkzCLY+iYUDW/Z3Adc/gpzyFrAqnALkJe+7DoItgAtRS2zuKqGE3yAx0oJvkdvYrfZmALURbDuL5/RLf13cAuDeBS2RpbtAm+QFVA3wR+3fUtFHoBDJnC0jIXH0HWsgMY8inPLuOkd9chp4z20ALQLSA8cI9jYAIa2zjzjBd8gRafS1vgiUho/kAKcsCGTOGWvoOpkAtB3z8Hm8x2Ff5ADp4+lXAlIvcmwH/2Q==') repeat left top;
+	border-radius: 5px;
+	border: 1px solid #000;
+	color: #DCCF8F;
+	background: #181914 url('data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD/7AARRHVja3kAAQAEAAAAMAAA/+4ADkFkb2JlAGTAAAAAAf/bAIQACQYGBgcGCQcHCQ0IBwgNDwsJCQsPEQ4ODw4OERENDg4ODg0RERQUFhQUERoaHBwaGiYmJiYmKysrKysrKysrKwEJCAgJCgkMCgoMDwwODA8TDg4ODhMVDg4PDg4VGhMRERERExoXGhYWFhoXHR0aGh0dJCQjJCQrKysrKysrKysr/8AAEQgAjACMAwEiAAIRAQMRAf/EAF4AAQEBAAAAAAAAAAAAAAAAAAABBwEBAQAAAAAAAAAAAAAAAAAAAAIQAAEDAwIHAQEAAAAAAAAAAADwAREhYaExkUFRcYGxwdHh8REBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AyGFEjHaBS2fDDs2zkhKmBKktb7km+ZwwCnXPkLVmCTMItj6AXFxRS465/BTnkAJvkLkJe+7AKKoi2AtRS2zuAWsCb5GOlBN8gKfmuGHZ8MFqIth3ALmFoFwbwKWyAlTAp17uKqBvgBD8sM4fTjhvAhkzhaRkBMKBrfs7jGPIpzy7gFrAqnC0C0gB0EWwBDW2cBVQwm+QtPpa3wBO3sVvszCnLAhkzgL5/RLf13cLQd8/AGlu0Cb5HTx9KuAEieGJEdcehS3eRTp2ATdt3CpIm+QtZwAhROXFeb7swp/ahaM3kBE/jSIUBc/AWrgBN8uNFAl+b7sAXFxFn2YLUU5Ns7gFX8C4ib+hN8gFWXwK3bZglxEJm+gKdciLPsFV/TClsgJUwKJ5FVA7tvIFrfZhVfGJDcsCKaYgAqv6YRbE+RWOWBtu7+AL3yRalXLyKqAIIfk+zARbDgFyEsncYwJvlgFRW+GEWntIi2P0BooyFxcNr8Ep3+ANLbMO+QyhvbiqdgC0kVvgUUiLYgBS2QtPbiVI1/sgOmG9uO+Y8DW+7jS2zAOnj6O2BndwuIAUtkdRN8gFoK3wwXMQyZwHVbClsuNLd4E3yAUR6FVDBR+BafQGt93LVMxJTv8ABts4CVLhcfYWsCb5kC9/BHdU8CLYFY5bMAd+eX9MGthhpbA1vu4B7+RKkaW2Yq4AQtVBBFsAJU/AuIXBhN8gGWnstefhiZyWvLAEnbYS1uzSFP6Jvn4Baxx70JKkQojLib5AVTey1jjgkKJGO0AKWyOm7N7cSpgSpAdPH0Tfd/gp1z5C1ZgKqN9J2wFxcUUuAFLZAm+QC0Fb4YUVRFsAOvj4KW2dwtYE3yAWk/wS/PLMKfmuGHZ8MAXF/Ja32Yi5haAKWz4Ydm2cSpgU693Atb7km+Zwwh+WGcPpxw3gAkzCLY+iYUDW/Z3Adc/gpzyFrAqnALkJe+7DoItgAtRS2zuKqGE3yAx0oJvkdvYrfZmALURbDuL5/RLf13cAuDeBS2RpbtAm+QFVA3wR+3fUtFHoBDJnC0jIXH0HWsgMY8inPLuOkd9chp4z20ALQLSA8cI9jYAIa2zjzjBd8gRafS1vgiUho/kAKcsCGTOGWvoOpkAtB3z8Hm8x2Ff5ADp4+lXAlIvcmwH/2Q==') repeat left top;
 }
 
 pre[class*="language-"] {
-    padding: 12px;
-    overflow: auto;
+	padding: 12px;
+	overflow: auto;
 }
 
 :not(pre) > code[class*="language-"] {
-    padding: 2px 6px;
+	padding: 2px 6px;
 }
 
 .token.namespace {
-    opacity: .7;
+	opacity: .7;
 }
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-    color: #586e75;
-    font-style: italic;
+	color: #586e75;
+	font-style: italic;
 }
 .token.number,
 .token.string,
 .token.char,
 .token.builtin,
 .token.inserted {
-    color: #468966;
+	color: #468966;
 }
 
 .token.attr-name {
-    color: #b89859;
+	color: #b89859;
 }
 .token.operator,
 .token.entity,
 .token.url,
 .language-css .token.string,
 .style .token.string {
-    color: #dccf8f;
+	color: #dccf8f;
 }
 .token.selector,
 .token.regex {
-    color: #859900;
+	color: #859900;
 }
 .token.atrule,
 .token.keyword {
-    color: #cb4b16;
+	color: #cb4b16;
 }
 
 .token.attr-value {
-    color:  #468966;
+	color: #468966;
 }
 .token.function,
 .token.variable,
 .token.placeholder {
-    color:  #b58900;
+	color: #b58900;
 }
 .token.property,
 .token.tag,
@@ -93,42 +97,42 @@ pre[class*="language-"] {
 .token.number,
 .token.constant,
 .token.symbol {
-    color: #b89859;
+	color: #b89859;
 }
 .token.tag {
-    color: #ffb03b;
+	color: #ffb03b;
 }
 .token.important,
 .token.statement,
 .token.deleted {
-    color: #dc322f;
+	color: #dc322f;
 }
 .token.punctuation {
-    color:  #dccf8f;
+	color: #dccf8f;
 }
 .token.entity {
-    cursor: help;
+	cursor: help;
 }
 .token.bold {
-    font-weight: bold;
+	font-weight: bold;
 }
 .token.italic {
-    font-style: italic;
+	font-style: italic;
 }
 
 /*
 .pojoaque-colors {
-    color: #586e75;
-    color: #b64926;
-    color: #468966;
-    color: #ffb03b;
-    color: #b58900;
-    color: #b89859;
-    color: #dccf8f;
-    color: #d3a60c;
-    color: #cb4b16;
-    color: #dc322f;
-    color: #073642;
-    color: #181914;
+	color: #586e75;
+	color: #b64926;
+	color: #468966;
+	color: #ffb03b;
+	color: #b58900;
+	color: #b89859;
+	color: #dccf8f;
+	color: #d3a60c;
+	color: #cb4b16;
+	color: #dc322f;
+	color: #073642;
+	color: #181914;
 }
 */

--- a/themes/prism-vs.css
+++ b/themes/prism-vs.css
@@ -5,71 +5,75 @@
 
 code[class*="language-"],
 pre[class*="language-"] {
-    color: #393A34;
-    font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
-    direction: ltr;
-    text-align: left;
-    white-space: pre;
-    word-spacing: normal;
-    word-break: normal;
-    font-size: 0.95em;
-    line-height: 1.2em;
+	color: #393A34;
+	font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	font-size: .9em;
+	line-height: 1.2em;
 
-    -moz-tab-size: 4;
-    -o-tab-size: 4;
-    tab-size: 4;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
 
-    -webkit-hyphens: none;
-    -moz-hyphens: none;
-    -ms-hyphens: none;
-    hyphens: none;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+pre > code[class*="language-"] {
+	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-    background: #C1DEF1;
+	background: #C1DEF1;
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
-    background: #C1DEF1;
+	background: #C1DEF1;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-    padding: 1em;
-    margin: .5em 0;
-    overflow: auto;
-    border: 1px solid #dddddd;
-    background-color: white;
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+	border: 1px solid #dddddd;
+	background-color: white;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-    padding: .2em;
-    padding-top: 1px; padding-bottom: 1px;
-    background: #f8f8f8;
-    border: 1px solid #dddddd;
+	padding: .2em;
+	padding-top: 1px; padding-bottom: 1px;
+	background: #f8f8f8;
+	border: 1px solid #dddddd;
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-    color: #008000; font-style: italic;
+	color: #008000; font-style: italic;
 }
 
 .token.namespace {
-    opacity: .7;
+	opacity: .7;
 }
 
 .token.string {
-    color: #A31515;
+	color: #A31515;
 }
 
 .token.punctuation,
 .token.operator {
-    color: #393A34; /* no highlight */
+	color: #393A34; /* no highlight */
 }
 
 .token.url,
@@ -79,79 +83,79 @@ pre[class*="language-"] {
 .token.variable,
 .token.constant,
 .token.inserted {
-    color: #36acaa;
+	color: #36acaa;
 }
 
 .token.atrule,
 .token.keyword,
 .token.attr-value,
 .language-autohotkey .token.selector,
-.language-json .token.boolean, 
-.language-json .token.number, 
+.language-json .token.boolean,
+.language-json .token.number,
 code[class*="language-css"]{
-    color: #0000ff;
+	color: #0000ff;
 }
 
 .token.function {
-    color: #393A34;
+	color: #393A34;
 }
 .token.deleted,
 .language-autohotkey .token.tag {
-    color: #9a050f;
+	color: #9a050f;
 }
 
 .token.selector,
 .language-autohotkey .token.keyword {
-    color: #00009f;
+	color: #00009f;
 }
 
 .token.important,
 .token.bold {
-    font-weight: bold;
+	font-weight: bold;
 }
 
 .token.italic {
-    font-style: italic;
+	font-style: italic;
 }
 
 .token.class-name,
 .language-json .token.property {
-    color: #2B91AF;
+	color: #2B91AF;
 }
 
 .token.tag,
 .token.selector {
-    color: #800000;
+	color: #800000;
 }
 
 .token.attr-name,
 .token.property,
 .token.regex,
 .token.entity {
-    color: #ff0000;
+	color: #ff0000;
 }
 
 .token.directive.tag  .tag {
-    background: #ffff00;
-    color: #393A34;
+	background: #ffff00;
+	color: #393A34;
 }
 
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
 .line-numbers .line-numbers-rows {
-  border-right-color: #a5a5a5;
+	border-right-color: #a5a5a5;
 }
 
 .line-numbers-rows > span:before {
-  color: #2B91AF;
+	color: #2B91AF;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
 .line-highlight {
-  background: rgba(193, 222, 241, 0.2);
-  background: -webkit-linear-gradient(left, rgba(193, 222, 241, 0.2) 70%, rgba(221, 222, 241, 0));
-  background: linear-gradient(to right, rgba(193, 222, 241, 0.2) 70%, rgba(221, 222, 241, 0));
+	background: rgba(193, 222, 241, 0.2);
+	background: -webkit-linear-gradient(left, rgba(193, 222, 241, 0.2) 70%, rgba(221, 222, 241, 0));
+	background: linear-gradient(to right, rgba(193, 222, 241, 0.2) 70%, rgba(221, 222, 241, 0));
 }

--- a/themes/prism-xonokai.css
+++ b/themes/prism-xonokai.css
@@ -5,160 +5,166 @@
 */
 code[class*="language-"],
 pre[class*="language-"] {
-    -moz-tab-size: 2;
-    -o-tab-size: 2;
-    tab-size: 2;
-    -webkit-hyphens: none;
-    -moz-hyphens: none;
-    -ms-hyphens: none;
-    hyphens: none;
-    white-space: pre;
-    white-space: pre-wrap;
-    word-wrap: normal;
-    font-family: Menlo, Monaco, "Courier New", monospace;
-    font-size: 14px;
-    color: #76d9e6;
-    text-shadow: none;
+	-moz-tab-size: 2;
+	-o-tab-size: 2;
+	tab-size: 2;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	white-space: pre;
+	white-space: pre-wrap;
+	word-wrap: normal;
+	font-family: Menlo, Monaco, "Courier New", monospace;
+	font-size: 14px;
+	color: #76d9e6;
+	text-shadow: none;
 }
+
+pre > code[class*="language-"] {
+	font-size: 1em;
+}
+
 pre[class*="language-"],
 :not(pre)>code[class*="language-"] {
-    background: #2a2a2a;
-}
-pre[class*="language-"] {
-    padding: 15px;
-    border-radius: 4px;
-    border: 1px solid #e1e1e8;
-    overflow: auto;
+	background: #2a2a2a;
 }
 
 pre[class*="language-"] {
-    position: relative;
+	padding: 15px;
+	border-radius: 4px;
+	border: 1px solid #e1e1e8;
+	overflow: auto;
+}
+
+pre[class*="language-"] {
+	position: relative;
 }
 pre[class*="language-"] code {
-    white-space: pre;
-    display: block;
+	white-space: pre;
+	display: block;
 }
 
 :not(pre)>code[class*="language-"] {
-    padding: 0.15em 0.2em 0.05em;
-    border-radius: .3em;
-    border: 0.13em solid #7a6652;
-    box-shadow: 1px 1px 0.3em -0.1em #000 inset;
+	padding: 0.15em 0.2em 0.05em;
+	border-radius: .3em;
+	border: 0.13em solid #7a6652;
+	box-shadow: 1px 1px 0.3em -0.1em #000 inset;
 }
 .token.namespace {
-    opacity: .7;
+	opacity: .7;
 }
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-    color: #6f705e;
+	color: #6f705e;
 }
 .token.operator,
 .token.boolean,
 .token.number {
-    color: #a77afe;
+	color: #a77afe;
 }
 .token.attr-name,
 .token.string {
-    color: #e6d06c;
+	color: #e6d06c;
 }
 .token.entity,
 .token.url,
 .language-css .token.string,
 .style .token.string {
-    color: #e6d06c;
+	color: #e6d06c;
 }
 .token.selector,
 .token.inserted {
-    color: #a6e22d;
+	color: #a6e22d;
 }
 .token.atrule,
 .token.attr-value,
 .token.keyword,
 .token.important,
 .token.deleted {
-    color: #ef3b7d;
+	color: #ef3b7d;
 }
 .token.regex,
 .token.statement {
-    color: #76d9e6;
+	color: #76d9e6;
 }
 .token.placeholder,
 .token.variable {
-    color: #fff;
+	color: #fff;
 }
 .token.important,
 .token.statement,
 .token.bold {
-    font-weight: bold;
+	font-weight: bold;
 }
 .token.punctuation {
-    color: #bebec5;
+	color: #bebec5;
 }
 .token.entity {
-    cursor: help;
+	cursor: help;
 }
 .token.italic {
-    font-style: italic;
+	font-style: italic;
 }
 
 code.language-markup {
-    color: #f9f9f9;
+	color: #f9f9f9;
 }
 code.language-markup .token.tag {
-    color: #ef3b7d;
+	color: #ef3b7d;
 }
 code.language-markup .token.attr-name {
-    color: #a6e22d;
+	color: #a6e22d;
 }
 code.language-markup .token.attr-value {
-    color: #e6d06c;
+	color: #e6d06c;
 }
 code.language-markup .token.style,
 code.language-markup .token.script {
-    color: #76d9e6;
+	color: #76d9e6;
 }
 code.language-markup .token.script .token.keyword {
-    color: #76d9e6;
+	color: #76d9e6;
 }
 
 /* Line highlight plugin */
 pre[class*="language-"][data-line] {
-    position: relative;
-    padding: 1em 0 1em 3em;
+	position: relative;
+	padding: 1em 0 1em 3em;
 }
 pre[data-line] .line-highlight {
-    position: absolute;
-    left: 0;
-    right: 0;
-    padding: 0;
-    margin-top: 1em;
-    background: rgba(255, 255, 255, 0.08);
-    pointer-events: none;
-    line-height: inherit;
-    white-space: pre;
+	position: absolute;
+	left: 0;
+	right: 0;
+	padding: 0;
+	margin-top: 1em;
+	background: rgba(255, 255, 255, 0.08);
+	pointer-events: none;
+	line-height: inherit;
+	white-space: pre;
 }
 pre[data-line] .line-highlight:before,
 pre[data-line] .line-highlight[data-end]:after {
-    content: attr(data-start);
-    position: absolute;
-    top: .4em;
-    left: .6em;
-    min-width: 1em;
-    padding: 0.2em 0.5em;
-    background-color: rgba(255, 255, 255, 0.4);
-    color: black;
-    font: bold 65%/1 sans-serif;
-    height: 1em;
-    line-height: 1em;
-    text-align: center;
-    border-radius: 999px;
-    text-shadow: none;
-    box-shadow: 0 1px 1px rgba(255, 255, 255, 0.7);
+	content: attr(data-start);
+	position: absolute;
+	top: .4em;
+	left: .6em;
+	min-width: 1em;
+	padding: 0.2em 0.5em;
+	background-color: rgba(255, 255, 255, 0.4);
+	color: black;
+	font: bold 65%/1 sans-serif;
+	height: 1em;
+	line-height: 1em;
+	text-align: center;
+	border-radius: 999px;
+	text-shadow: none;
+	box-shadow: 0 1px 1px rgba(255, 255, 255, 0.7);
 }
 pre[data-line] .line-highlight[data-end]:after {
-    content: attr(data-end);
-    top: auto;
-    bottom: .4em;
+	content: attr(data-end);
+	top: auto;
+	bottom: .4em;
 }


### PR DESCRIPTION
This fixes [prism#1946](https://github.com/PrismJS/prism/issues/1946).

The problem was that the `<code>` element nested inside the `<pre>` element has to have the same font size as the `pre`.  I added a little rule to nearly every theme to enforce just this.

```css
pre > code[class*="language-"] {
	font-size: 1em;
}
```

---

This also enforces tabs for indentation for all theme.