### PR TITLE
Added a linter and checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+package-lock.json

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,14 @@
+{
+	"extends": "stylelint-config-standard",
+	"rules": {
+		"color-hex-case": null,
+		"color-hex-length": null,
+		"comment-empty-line-before": null,
+		"declaration-empty-line-before": null,
+		"indentation": "tab",
+		"no-descending-specificity": null,
+		"number-leading-zero": null,
+		"selector-list-comma-newline-after": null,
+		"selector-pseudo-element-colon-notation": "single"
+	}
+}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ The links for your themes have to be `themes/prism-<your theme>.css` for the the
 The screenshot will be created for you by running the following command:
 
 ```bash
-npm ci && npx gulp screenshot
+npm i && npx gulp screenshot
+```
+
+Before making a pull request, you can the following command to verify that all checks pass:
+
+```bash
+npm test
 ```
 
 Thank you so much for contributing!!

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "prism-themes",
   "version": "1.3.0",
-  "description": "Addtional themes for the Prism syntax highlighting library.",
+  "description": "Additional themes for the Prism syntax highlighting library.",
   "main": "README.md",
   "scripts": {
-    "test": "echo \"Error: no tests required\" && exit 0"
+    "lint": "npx stylelint \"themes/*.css\"",
+    "lint-fix": "npx stylelint \"themes/*.css\" --fix",
+    "test": "npm run lint"
   },
   "repository": {
     "type": "git",
@@ -18,6 +20,8 @@
   "homepage": "https://github.com/prismjs/prism-themes#readme",
   "devDependencies": {
     "capture-website": "^0.4.0",
-    "gulp": "^4.0.2"
+    "gulp": "^4.0.2",
+    "stylelint": "^12.0.0",
+    "stylelint-config-standard": "^19.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Additional themes for the Prism syntax highlighting library.",
   "main": "README.md",
   "scripts": {
-    "lint": "npx stylelint \"themes/*.css\"",
-    "lint-fix": "npx stylelint \"themes/*.css\" --fix",
+    "lint": "stylelint \"themes/*.css\"",
+    "lint-fix": "stylelint \"themes/*.css\" --fix",
     "test": "npm run lint"
   },
   "repository": {

--- a/themes/prism-a11y-dark.css
+++ b/themes/prism-a11y-dark.css
@@ -107,6 +107,7 @@ pre[class*="language-"] {
 .token.bold {
 	font-weight: bold;
 }
+
 .token.italic {
 	font-style: italic;
 }

--- a/themes/prism-atom-dark.css
+++ b/themes/prism-atom-dark.css
@@ -104,7 +104,7 @@ pre[class*="language-"] {
 
 .token.entity {
 	color: #FFFFB6;
-	/* text-decoration: underline; */
+	cursor: help;
 }
 
 .token.url {
@@ -137,10 +137,7 @@ pre[class*="language-"] {
 .token.bold {
 	font-weight: bold;
 }
+
 .token.italic {
 	font-style: italic;
-}
-
-.token.entity {
-	cursor: help;
 }

--- a/themes/prism-cb.css
+++ b/themes/prism-cb.css
@@ -135,7 +135,7 @@ pre[data-line] {
 	left: 0;
 	right: 0;
 	margin-top: 1em; /* Same as .prism's padding-top */
-	background: rgba(255,255,255,.2);
+	background: rgba(255, 255, 255, .2);
 	pointer-events: none;
 	line-height: inherit;
 	white-space: pre;
@@ -149,7 +149,7 @@ pre[data-line] {
 	left: .6em;
 	min-width: 1em;
 	padding: 0 .5em;
-	background-color: rgba(255,255,255,.3);
+	background-color: rgba(255, 255, 255, .3);
 	color: #fff;
 	font: bold 65%/1.5 sans-serif;
 	text-align: center;

--- a/themes/prism-darcula.css
+++ b/themes/prism-darcula.css
@@ -32,13 +32,13 @@ pre[class*="language-"] {
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
 	color: inherit;
-	background: rgba(33,66,131,.85);
+	background: rgba(33, 66, 131, .85);
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
 	color: inherit;
-	background: rgba(33,66,131,.85);
+	background: rgba(33, 66, 131, .85);
 }
 
 /* Code blocks */
@@ -108,6 +108,7 @@ pre[class*="language-"] {
 .token.attr-value .punctuation {
 	color: #a5c261;
 }
+
 .token.attr-value .punctuation:first-child {
 	color: #a9b7c6;
 }
@@ -140,10 +141,6 @@ pre[class*="language-"] {
 .token.deleted {
 	background: #484a4a;
 }
-
-/*code.language-css .token.punctuation {
-	color: #cc7832;
-}*/
 
 code.language-css .token.property,
 code.language-css .token.property + .token.punctuation {

--- a/themes/prism-dracula.css
+++ b/themes/prism-dracula.css
@@ -23,47 +23,56 @@ pre[class*="language-"] {
 	-webkit-hyphens: none;
 	-moz-hyphens: none;
 	-ms-hyphens: none;
-	hyphens: none; }
+	hyphens: none;
+}
 
 /* Code blocks */
 pre[class*="language-"] {
 	padding: 1em;
 	margin: .5em 0;
 	overflow: auto;
-	border-radius: 0.3em; }
+	border-radius: 0.3em;
+}
 
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
-	background: #282a36; }
+	background: #282a36;
+}
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
 	padding: .1em;
 	border-radius: .3em;
-	white-space: normal; }
+	white-space: normal;
+}
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-	color: #6272a4; }
+	color: #6272a4;
+}
 
 .token.punctuation {
-	color: #f8f8f2; }
+	color: #f8f8f2;
+}
 
 .namespace {
-	opacity: .7; }
+	opacity: .7;
+}
 
 .token.property,
 .token.tag,
 .token.constant,
 .token.symbol,
 .token.deleted {
-	color: #ff79c6; }
+	color: #ff79c6;
+}
 
 .token.boolean,
 .token.number {
-	color: #bd93f9; }
+	color: #bd93f9;
+}
 
 .token.selector,
 .token.attr-name,
@@ -71,7 +80,8 @@ pre[class*="language-"] {
 .token.char,
 .token.builtin,
 .token.inserted {
-	color: #50fa7b; }
+	color: #50fa7b;
+}
 
 .token.operator,
 .token.entity,
@@ -79,28 +89,34 @@ pre[class*="language-"] {
 .language-css .token.string,
 .style .token.string,
 .token.variable {
-	color: #f8f8f2; }
+	color: #f8f8f2;
+}
 
 .token.atrule,
 .token.attr-value,
 .token.function,
 .token.class-name {
-	color: #f1fa8c; }
+	color: #f1fa8c;
+}
 
 .token.keyword {
-	color: #8be9fd; }
+	color: #8be9fd;
+}
 
 .token.regex,
 .token.important {
-	color: #ffb86c; }
+	color: #ffb86c;
+}
 
 .token.important,
 .token.bold {
-	font-weight: bold; }
+	font-weight: bold;
+}
 
 .token.italic {
-	font-style: italic; }
+	font-style: italic;
+}
 
 .token.entity {
-	cursor: help; }
-
+	cursor: help;
+}

--- a/themes/prism-ghcolors.css
+++ b/themes/prism-ghcolors.css
@@ -51,7 +51,8 @@ pre[class*="language-"] {
 /* Inline code */
 :not(pre) > code[class*="language-"] {
 	padding: .2em;
-	padding-top: 1px; padding-bottom: 1px;
+	padding-top: 1px;
+	padding-bottom: 1px;
 	background: #f8f8f8;
 	border: 1px solid #dddddd;
 }
@@ -60,7 +61,8 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-	color: #999988; font-style: italic;
+	color: #999988;
+	font-style: italic;
 }
 
 .token.namespace {
@@ -71,6 +73,7 @@ pre[class*="language-"] {
 .token.attr-value {
 	color: #e3116c;
 }
+
 .token.punctuation,
 .token.operator {
 	color: #393A34; /* no highlight */

--- a/themes/prism-hopscotch.css
+++ b/themes/prism-hopscotch.css
@@ -9,8 +9,7 @@
 
 code[class*="language-"],
 pre[class*="language-"] {
-	color: #ffffff;
-	font-family: "Fira Mono", Menlo, Monaco, "Lucida Console","Courier New", Courier, monospace;
+	font-family: "Fira Mono", Menlo, Monaco, "Lucida Console", "Courier New", Courier, monospace;
 	font-size: 16px;
 	line-height: 1.375;
 	direction: ltr;
@@ -71,21 +70,27 @@ pre[class*="language-"] {
 .token.number {
 	color: #fd8b19;
 }
+
 .token.property {
 	color: #fdcc59;
 }
+
 .token.tag {
 	color: #1290bf;
 }
+
 .token.string {
 	color: #149b93;
 }
+
 .token.selector {
 	color: #c85e7c;
 }
+
 .token.attr-name {
 	color: #fd8b19;
 }
+
 .token.entity,
 .token.url,
 .language-css .token.string,
@@ -125,4 +130,3 @@ pre > code.highlight {
 	outline: .4em solid red;
 	outline-offset: .4em;
 }
-

--- a/themes/prism-material-light.css
+++ b/themes/prism-material-light.css
@@ -25,7 +25,7 @@ code[class*="language-"]::-moz-selection,
 pre[class*="language-"]::-moz-selection,
 code[class*="language-"] ::-moz-selection,
 pre[class*="language-"] ::-moz-selection {
-	background: #cceae7; 
+	background: #cceae7;
 	color: #263238;
 }
 

--- a/themes/prism-pojoaque.css
+++ b/themes/prism-pojoaque.css
@@ -49,6 +49,7 @@ pre[class*="language-"] {
 .token.namespace {
 	opacity: .7;
 }
+
 .token.comment,
 .token.prolog,
 .token.doctype,
@@ -56,6 +57,7 @@ pre[class*="language-"] {
 	color: #586e75;
 	font-style: italic;
 }
+
 .token.number,
 .token.string,
 .token.char,
@@ -67,6 +69,7 @@ pre[class*="language-"] {
 .token.attr-name {
 	color: #b89859;
 }
+
 .token.operator,
 .token.entity,
 .token.url,
@@ -74,10 +77,12 @@ pre[class*="language-"] {
 .style .token.string {
 	color: #dccf8f;
 }
+
 .token.selector,
 .token.regex {
 	color: #859900;
 }
+
 .token.atrule,
 .token.keyword {
 	color: #cb4b16;
@@ -86,11 +91,13 @@ pre[class*="language-"] {
 .token.attr-value {
 	color: #468966;
 }
+
 .token.function,
 .token.variable,
 .token.placeholder {
 	color: #b58900;
 }
+
 .token.property,
 .token.tag,
 .token.boolean,
@@ -99,23 +106,29 @@ pre[class*="language-"] {
 .token.symbol {
 	color: #b89859;
 }
+
 .token.tag {
 	color: #ffb03b;
 }
+
 .token.important,
 .token.statement,
 .token.deleted {
 	color: #dc322f;
 }
+
 .token.punctuation {
 	color: #dccf8f;
 }
+
 .token.entity {
 	cursor: help;
 }
+
 .token.bold {
 	font-weight: bold;
 }
+
 .token.italic {
 	font-style: italic;
 }

--- a/themes/prism-shades-of-purple.css
+++ b/themes/prism-shades-of-purple.css
@@ -123,6 +123,7 @@ pre[class*='language-'] {
 .token.attr-value .punctuation {
 	color: #a5c261;
 }
+
 .token.attr-value .punctuation:first-child {
 	color: #a9b7c6;
 }

--- a/themes/prism-synthwave84.css
+++ b/themes/prism-synthwave84.css
@@ -27,7 +27,6 @@ pre[class*="language-"] {
 	-moz-hyphens: none;
 	-ms-hyphens: none;
 	hyphens: none;
-
 }
 
 /* Code blocks */
@@ -37,14 +36,14 @@ pre[class*="language-"] {
 	overflow: auto;
 }
 
-:not(pre)>code[class*="language-"],
+:not(pre) > code[class*="language-"],
 pre[class*="language-"] {
 	background-color: transparent !important;
 	background-image: linear-gradient(to bottom, #2a2139 75%, #34294f);
 }
 
 /* Inline code */
-:not(pre)>code[class*="language-"] {
+:not(pre) > code[class*="language-"] {
 	padding: .1em;
 	border-radius: .3em;
 	white-space: normal;
@@ -87,7 +86,6 @@ pre[class*="language-"] {
 .token.function {
 	color: #fdfdfd;
 	text-shadow: 0 0 2px #001716, 0 0 3px #03edf975, 0 0 5px #03edf975, 0 0 8px #03edf975;
-
 }
 
 .token.class-name {

--- a/themes/prism-vs.css
+++ b/themes/prism-vs.css
@@ -51,7 +51,8 @@ pre[class*="language-"] {
 /* Inline code */
 :not(pre) > code[class*="language-"] {
 	padding: .2em;
-	padding-top: 1px; padding-bottom: 1px;
+	padding-top: 1px;
+	padding-bottom: 1px;
 	background: #f8f8f8;
 	border: 1px solid #dddddd;
 }
@@ -60,7 +61,8 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-	color: #008000; font-style: italic;
+	color: #008000;
+	font-style: italic;
 }
 
 .token.namespace {
@@ -92,13 +94,14 @@ pre[class*="language-"] {
 .language-autohotkey .token.selector,
 .language-json .token.boolean,
 .language-json .token.number,
-code[class*="language-css"]{
+code[class*="language-css"] {
 	color: #0000ff;
 }
 
 .token.function {
 	color: #393A34;
 }
+
 .token.deleted,
 .language-autohotkey .token.tag {
 	color: #9a050f;
@@ -135,7 +138,7 @@ code[class*="language-css"]{
 	color: #ff0000;
 }
 
-.token.directive.tag  .tag {
+.token.directive.tag .tag {
 	background: #ffff00;
 	color: #393A34;
 }

--- a/themes/prism-xonokai.css
+++ b/themes/prism-xonokai.css
@@ -26,7 +26,7 @@ pre > code[class*="language-"] {
 }
 
 pre[class*="language-"],
-:not(pre)>code[class*="language-"] {
+:not(pre) > code[class*="language-"] {
 	background: #2a2a2a;
 }
 
@@ -35,50 +35,55 @@ pre[class*="language-"] {
 	border-radius: 4px;
 	border: 1px solid #e1e1e8;
 	overflow: auto;
-}
-
-pre[class*="language-"] {
 	position: relative;
 }
+
 pre[class*="language-"] code {
 	white-space: pre;
 	display: block;
 }
 
-:not(pre)>code[class*="language-"] {
+:not(pre) > code[class*="language-"] {
 	padding: 0.15em 0.2em 0.05em;
 	border-radius: .3em;
 	border: 0.13em solid #7a6652;
 	box-shadow: 1px 1px 0.3em -0.1em #000 inset;
 }
+
 .token.namespace {
 	opacity: .7;
 }
+
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
 	color: #6f705e;
 }
+
 .token.operator,
 .token.boolean,
 .token.number {
 	color: #a77afe;
 }
+
 .token.attr-name,
 .token.string {
 	color: #e6d06c;
 }
+
 .token.entity,
 .token.url,
 .language-css .token.string,
 .style .token.string {
 	color: #e6d06c;
 }
+
 .token.selector,
 .token.inserted {
 	color: #a6e22d;
 }
+
 .token.atrule,
 .token.attr-value,
 .token.keyword,
@@ -86,25 +91,31 @@ pre[class*="language-"] code {
 .token.deleted {
 	color: #ef3b7d;
 }
+
 .token.regex,
 .token.statement {
 	color: #76d9e6;
 }
+
 .token.placeholder,
 .token.variable {
 	color: #fff;
 }
+
 .token.important,
 .token.statement,
 .token.bold {
 	font-weight: bold;
 }
+
 .token.punctuation {
 	color: #bebec5;
 }
+
 .token.entity {
 	cursor: help;
 }
+
 .token.italic {
 	font-style: italic;
 }
@@ -112,19 +123,24 @@ pre[class*="language-"] code {
 code.language-markup {
 	color: #f9f9f9;
 }
+
 code.language-markup .token.tag {
 	color: #ef3b7d;
 }
+
 code.language-markup .token.attr-name {
 	color: #a6e22d;
 }
+
 code.language-markup .token.attr-value {
 	color: #e6d06c;
 }
+
 code.language-markup .token.style,
 code.language-markup .token.script {
 	color: #76d9e6;
 }
+
 code.language-markup .token.script .token.keyword {
 	color: #76d9e6;
 }
@@ -134,6 +150,7 @@ pre[class*="language-"][data-line] {
 	position: relative;
 	padding: 1em 0 1em 3em;
 }
+
 pre[data-line] .line-highlight {
 	position: absolute;
 	left: 0;
@@ -145,6 +162,7 @@ pre[data-line] .line-highlight {
 	line-height: inherit;
 	white-space: pre;
 }
+
 pre[data-line] .line-highlight:before,
 pre[data-line] .line-highlight[data-end]:after {
 	content: attr(data-start);
@@ -163,6 +181,7 @@ pre[data-line] .line-highlight[data-end]:after {
 	text-shadow: none;
 	box-shadow: 0 1px 1px rgba(255, 255, 255, 0.7);
 }
+
 pre[data-line] .line-highlight[data-end]:after {
 	content: attr(data-end);
 	top: auto;


### PR DESCRIPTION
This adds [stylelint](https://stylelint.io/) (a CSS linter) and a few checks in gulp as well as some minor changes.

__stylelint:__

Stylelint is the CSS linter I choose. It does what I want a CSS linter to do and that's it. If you know a better linter, we can switch anytime.

I configured the linter such that there are as few modifications as possible. The only things that changed in the CSS files are some whitespaces and newlines. All non-whitespace changes in the themes are errors that the linter pointed out.

To make the linter stricter, we just have re-enable the rules I disabled (all rules which are set to `null`). [Here](https://stylelint.io/user-guide/rules) is the documentation of all rules.

__gulp checks:__

I also added two checks, which 1) check that every theme has a screenshot and 2) that every theme (plus screenshot) is in the readme.

Both checks and the linter will be run by Travis. 
(Yay, Travis is actually doing something now!)

__Minor changes:__

* Fixed a typo in `package.json`.
* `npm ci`, as described in the README, doesn't work without `package-lock.json`, so I changed it to `npm i` and added the `package-lock.json` to the `.gitignore`.