### PR TITLE
Added .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+screenshots/
+.stylelintrc.json
+.travis.yml
+gulpfile.js


### PR DESCRIPTION
I noticed that all of our screenshots are also part of the `prism-themes` package, for some reason.