### PR TITLE
Adding "token.important" class color

### DIFF
--- a/themes/prism-vs.css
+++ b/themes/prism-vs.css
@@ -112,6 +112,10 @@ code[class*="language-css"] {
 	color: #00009f;
 }
 
+.token.important {
+	color: #e90;
+}
+
 .token.important,
 .token.bold {
 	font-weight: bold;


### PR DESCRIPTION
The `token.important` css class is absent in theme. Copied it's value from system `Coy` theme