### PR TITLE
VS Code Dark Plus: Fix colors for inserted and deleted in diffs

### DIFF
--- a/themes/prism-vsc-dark-plus.css
+++ b/themes/prism-vsc-dark-plus.css
@@ -79,7 +79,7 @@ pre[class*="language-"] {
 .token.number,
 .token.constant,
 .token.symbol,
-.token.deleted,
+.token.inserted,
 .token.unit {
 	color: #b5cea8;
 }
@@ -89,7 +89,7 @@ pre[class*="language-"] {
 .token.string,
 .token.char,
 .token.builtin,
-.token.inserted {
+.token.deleted {
 	color: #ce9178;
 }
 


### PR DESCRIPTION
Currently the colors are incorrect (flipped) for the `inserted` and `deleted` tokens in the `prism-vsc-dark-plus.css` theme:

![Screen Shot 2020-10-23 at 13 33 26](https://user-images.githubusercontent.com/1935696/96998789-67ddbd80-1534-11eb-81d3-cff71639cb3d.png)
