### PR TITLE
Use other class name to fix highlighting

### DIFF
--- a/themes/prism-vsc-dark-plus.css
+++ b/themes/prism-vsc-dark-plus.css
@@ -173,7 +173,7 @@ pre[class*="language-"] {
 	color: #9cdcfe;
 }
 
-.token.punctuation.interpolation-punctuation {
+.token.interpolation.interpolation-punctuation {
 	color: #569cd6;
 }
 


### PR DESCRIPTION
Hi @RunDevelopment !

`.punctuation` actually works in Prism itself, but fails in React Syntax Highlighter due to a 3-class limit: https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/07f5fc5a57945b3e5254bfddade2f7a8087bf095/src/create-element.js#L19-L20

This doesn't change anything for Prism, but makes the highlighting work in React Syntax Highlighter (who take their themes from this repo).

**Before (light blue - wrong)**

![Screen Shot 2020-11-04 at 18 26 08](https://user-images.githubusercontent.com/1935696/98146126-a035b200-1ecb-11eb-8267-ad08fc877bcf.png)

**After (dark blue - correct)**

![Screen Shot 2020-11-04 at 18 26 18](https://user-images.githubusercontent.com/1935696/98146203-ad52a100-1ecb-11eb-85e6-441256260010.png)
