### PR TITLE
Update Coldark Themes - Minor color change

### DIFF
--- a/themes/prism-coldark-cold.css
+++ b/themes/prism-coldark-cold.css
@@ -130,7 +130,7 @@ pre[class*="language-"] {
 
 .token.deleted,
 .token.important {
-	color: #c70100;
+	color: #c22f2e;
 }
 
 .token.keyword-this,
@@ -297,7 +297,7 @@ pre[id].linkable-line-numbers span.line-numbers-rows > span:hover:before {
  */
 pre.diff-highlight > code .token.deleted:not(.prefix),
 pre > code.diff-highlight .token.deleted:not(.prefix) {
-	background-color: #c701001f;
+	background-color: #c22f2e1f;
 }
 
 pre.diff-highlight > code .token.inserted:not(.prefix),

--- a/themes/prism-coldark-dark.css
+++ b/themes/prism-coldark-dark.css
@@ -130,7 +130,7 @@ pre[class*="language-"] {
 
 .token.deleted,
 .token.important {
-	color: #f57a73;
+	color: #cd6660;
 }
 
 .token.keyword-this,
@@ -297,7 +297,7 @@ pre[id].linkable-line-numbers span.line-numbers-rows > span:hover:before {
  */
 pre.diff-highlight > code .token.deleted:not(.prefix),
 pre > code.diff-highlight .token.deleted:not(.prefix) {
-	background-color: #f57a731f;
+	background-color: #cd66601f;
 }
 
 pre.diff-highlight > code .token.inserted:not(.prefix),


### PR DESCRIPTION
With some ports, some errors in the terminal were not readable. By changing the red color, readability is improved. This update is not unique to Prism and should not change the visual (red is only used for invalid elements or deletions). All Coldark ports are updated to use the correct colors.

See ArmandPhilippot/coldark-vscode#1

This time, I think the Prism version is pretty stable. Unless there is a change in Prism tokens, this version should no longer evolve.
I have not regenerated screenshots since they do not use the color red for this theme. I ran `npm test` and no error came out.