### PR TITLE
remove main field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "prism-themes",
   "version": "1.5.0",
   "description": "Additional themes for the Prism syntax highlighting library.",
-  "main": "README.md",
   "scripts": {
     "lint": "stylelint \"themes/*.css\"",
     "lint-fix": "stylelint \"themes/*.css\" --fix",


### PR DESCRIPTION
* prism-themes is a pure css package, doesn't have to contain a main field
* there's issue when prism-themes as dependency. like bundler might traverse dependency and pre-bundle/pre-compile it.

e.g. `browserless` is depending on `prism-themes`. when I use [pkg](https://github.com/vercel/pkg) to bundle a script using browserless. prism-themes is failed to be bundled