### PR TITLE
build: add Node.js main file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const path = require('path')
 
 module.exports = {
-  folderPath: path.resolve(__dirname, 'themes')
+	themesDirectory: path.resolve(__dirname, 'themes')
 }

--- a/index.js
+++ b/index.js
@@ -2,4 +2,4 @@ const path = require('path');
 
 module.exports = {
 	themesDirectory: path.resolve(__dirname, 'themes');
-}
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const path = require('path')
+const path = require('path');
 
 module.exports = {
-	themesDirectory: path.resolve(__dirname, 'themes')
+	themesDirectory: path.resolve(__dirname, 'themes');
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const path = require('path');
 
 module.exports = {
-	themesDirectory: path.resolve(__dirname, 'themes');
+	themesDirectory: path.resolve(__dirname, 'themes')
 };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+const path = require('path')
+
+module.exports = {
+  folderPath: path.resolve(__dirname, 'themes')
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "prism-themes",
   "version": "1.6.0",
   "description": "Additional themes for the Prism syntax highlighting library.",
+  "main": "index.js",
   "scripts": {
     "lint": "stylelint \"themes/*.css\"",
     "lint-fix": "stylelint \"themes/*.css\" --fix",


### PR DESCRIPTION
Hello,

In a previous PR (#114) the `main` field at `package.json` was removed because it was causing not useful.

This PR adds the field again but rather than pointing to a filesystem folder, it's returning the absolute path where the themes are living:

```js
require('prism-themes')
// {
//  folderPath: '/Users/kikobeats/Projects/microlink/browserless/packages/screenshot/node_modules/prism-themes/themes'
// }
```

This is actually useful because for some bundle workflow you need the reference of the folder to copy or load the themes.

In this way, it prevents copy the whole folder, but you still have a reference to the folder path in case you need it.