### PR TITLE
fix: code selection color and background

### DIFF
--- a/themes/prism-holi-theme.css
+++ b/themes/prism-holi-theme.css
@@ -38,8 +38,8 @@ pre[class*='language-']::selection,
 pre[class*='language-'] ::selection,
 code[class*='language-']::selection,
 code[class*='language-'] ::selection {
-	color: #d6e7ff;
-	background: #030314;
+	color: inherit;
+	background: #1d3b54;
 	text-shadow: none;
 }
 


### PR DESCRIPTION
Hey, I just noticed that the pre and code text selection colors were the same as the element's. This PR fixes them.

Please consider accepting the PR. Thank you.