### PR TITLE
VSC Dark+: Fixed light background and selection color

### DIFF
--- a/themes/prism-vsc-dark-plus.css
+++ b/themes/prism-vsc-dark-plus.css
@@ -24,7 +24,7 @@ code[class*="language-"]::selection,
 pre[class*="language-"] *::selection,
 code[class*="language-"] *::selection {
 	text-shadow: none;
-	background: #75a7ca;
+	background: #264F78;
 }
 
 @media print {
@@ -45,7 +45,7 @@ pre[class*="language-"] {
 	padding: .1em .3em;
 	border-radius: .3em;
 	color: #db4c69;
-	background: #f9f2f4;
+	background: #1e1e1e;
 }
 /*********************************************************
 * Tokens


### PR DESCRIPTION
This fixes #137. 

I also fixed the light selection color. It now uses the actual color instead.