### PR TITLE
Consistent font size

### DIFF
--- a/themes/prism-a11y-dark.css
+++ b/themes/prism-a11y-dark.css
@@ -9,6 +9,7 @@ pre[class*="language-"] {
 	color: #f8f8f2;
 	background: none;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-atom-dark.css
+++ b/themes/prism-atom-dark.css
@@ -9,6 +9,7 @@ pre[class*="language-"] {
 	color: #c5c8c6;
 	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
 	font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
+	font-size: 1em;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-base16-ateliersulphurpool.light.css
+++ b/themes/prism-base16-ateliersulphurpool.light.css
@@ -10,7 +10,7 @@ Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/b
 code[class*="language-"],
 pre[class*="language-"] {
 	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-	font-size: 14px;
+	font-size: 1em;
 	line-height: 1.375;
 	direction: ltr;
 	text-align: left;
@@ -26,10 +26,6 @@ pre[class*="language-"] {
 	hyphens: none;
 	background: #f5f7ff;
 	color: #5e6687;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,

--- a/themes/prism-cb.css
+++ b/themes/prism-cb.css
@@ -13,6 +13,7 @@ pre[class*="language-"] {
 	color: #fff;
 	text-shadow: 0 1px 1px #000;
 	font-family: Menlo, Monaco, "Courier New", monospace;
+	font-size: 1em;
 	direction: ltr;
 	text-align: left;
 	word-spacing: normal;
@@ -34,7 +35,7 @@ pre[class*="language-"] {
 
 pre[class*="language-"] code {
 	float: left;
-	padding: 0 15px 0 0;
+	padding: 0 1em 0 0;
 }
 
 pre[class*="language-"],
@@ -44,21 +45,21 @@ pre[class*="language-"],
 
 /* Code blocks */
 pre[class*="language-"] {
-	padding: 15px;
+	padding: 1em;
 	margin: 1em 0;
 	overflow: auto;
-	-moz-border-radius: 8px;
-	-webkit-border-radius: 8px;
-	border-radius: 8px;
+	-moz-border-radius: .5em;
+	-webkit-border-radius: .5em;
+	border-radius: .5em;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-	padding: 5px 10px;
+	padding: .3em .6em;
 	line-height: 1;
-	-moz-border-radius: 3px;
-	-webkit-border-radius: 3px;
-	border-radius: 3px;
+	-moz-border-radius: .2em;
+	-webkit-border-radius: .2em;
+	border-radius: .2em;
 }
 
 .token.comment,
@@ -153,9 +154,9 @@ pre[data-line] {
 	color: #fff;
 	font: bold 65%/1.5 sans-serif;
 	text-align: center;
-	-moz-border-radius: 8px;
-	-webkit-border-radius: 8px;
-	border-radius: 8px;
+	-moz-border-radius: .5em;
+	-webkit-border-radius: .5em;
+	border-radius: .5em;
 	text-shadow: none;
 }
 
@@ -171,6 +172,6 @@ pre[data-line] {
 }
 
 .line-numbers-rows span {
-	padding-right: 10px;
-	border-right: 3px #d9d336 solid;
+	padding-right: .6em;
+	border-right: .2em #d9d336 solid;
 }

--- a/themes/prism-coldark-cold.css
+++ b/themes/prism-coldark-cold.css
@@ -11,6 +11,7 @@ pre[class*="language-"] {
 	color: #111b27;
 	background: none;
 	font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-coldark-dark.css
+++ b/themes/prism-coldark-dark.css
@@ -11,6 +11,7 @@ pre[class*="language-"] {
 	color: #e3eaf2;
 	background: none;
 	font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-darcula.css
+++ b/themes/prism-darcula.css
@@ -12,6 +12,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: #a9b7c6;
 	font-family: Consolas, Monaco, 'Andale Mono', monospace;
+	font-size: 1em;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-dracula.css
+++ b/themes/prism-dracula.css
@@ -11,6 +11,7 @@ pre[class*="language-"] {
 	background: none;
 	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-duotone-dark.css
+++ b/themes/prism-duotone-dark.css
@@ -9,7 +9,7 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 code[class*="language-"],
 pre[class*="language-"] {
 	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-	font-size: 14px;
+	font-size: 1em;
 	line-height: 1.375;
 	direction: ltr;
 	text-align: left;
@@ -27,10 +27,6 @@ pre[class*="language-"] {
 	hyphens: none;
 	background: #2a2734;
 	color: #9a86fd;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,

--- a/themes/prism-duotone-earth.css
+++ b/themes/prism-duotone-earth.css
@@ -9,7 +9,7 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 code[class*="language-"],
 pre[class*="language-"] {
 	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-	font-size: 14px;
+	font-size: 1em;
 	line-height: 1.375;
 	direction: ltr;
 	text-align: left;
@@ -27,10 +27,6 @@ pre[class*="language-"] {
 	hyphens: none;
 	background: #322d29;
 	color: #88786d;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,

--- a/themes/prism-duotone-forest.css
+++ b/themes/prism-duotone-forest.css
@@ -9,7 +9,7 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 code[class*="language-"],
 pre[class*="language-"] {
 	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-	font-size: 14px;
+	font-size: 1em;
 	line-height: 1.375;
 	direction: ltr;
 	text-align: left;
@@ -27,10 +27,6 @@ pre[class*="language-"] {
 	hyphens: none;
 	background: #2a2d2a;
 	color: #687d68;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,

--- a/themes/prism-duotone-light.css
+++ b/themes/prism-duotone-light.css
@@ -9,7 +9,7 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 code[class*="language-"],
 pre[class*="language-"] {
 	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-	font-size: 14px;
+	font-size: 1em;
 	line-height: 1.375;
 	direction: ltr;
 	text-align: left;
@@ -27,10 +27,6 @@ pre[class*="language-"] {
 	hyphens: none;
 	background: #faf8f5;
 	color: #728fcb;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,

--- a/themes/prism-duotone-sea.css
+++ b/themes/prism-duotone-sea.css
@@ -9,7 +9,7 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 code[class*="language-"],
 pre[class*="language-"] {
 	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-	font-size: 14px;
+	font-size: 1em;
 	line-height: 1.375;
 	direction: ltr;
 	text-align: left;
@@ -27,10 +27,6 @@ pre[class*="language-"] {
 	hyphens: none;
 	background: #1d262f;
 	color: #57718e;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,

--- a/themes/prism-duotone-space.css
+++ b/themes/prism-duotone-space.css
@@ -9,7 +9,7 @@ Generated with Base16 Builder (https://github.com/base16-builder/base16-builder)
 code[class*="language-"],
 pre[class*="language-"] {
 	font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
-	font-size: 14px;
+	font-size: 1em;
 	line-height: 1.375;
 	direction: ltr;
 	text-align: left;
@@ -27,10 +27,6 @@ pre[class*="language-"] {
 	hyphens: none;
 	background: #24242e;
 	color: #767693;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,

--- a/themes/prism-ghcolors.css
+++ b/themes/prism-ghcolors.css
@@ -12,7 +12,7 @@ pre[class*="language-"] {
 	white-space: pre;
 	word-spacing: normal;
 	word-break: normal;
-	font-size: .9em;
+	font-size: 1em;
 	line-height: 1.2em;
 
 	-moz-tab-size: 4;
@@ -23,10 +23,6 @@ pre[class*="language-"] {
 	-moz-hyphens: none;
 	-ms-hyphens: none;
 	hyphens: none;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,

--- a/themes/prism-gruvbox-dark.css
+++ b/themes/prism-gruvbox-dark.css
@@ -12,6 +12,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: #ebdbb2; /* fg1 / fg */
 	font-family: Consolas, Monaco, "Andale Mono", monospace;
+	font-size: 1em;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-gruvbox-light.css
+++ b/themes/prism-gruvbox-light.css
@@ -12,6 +12,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: #3c3836; /* fg1 / fg */
 	font-family: Consolas, Monaco, "Andale Mono", monospace;
+	font-size: 1em;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-hopscotch.css
+++ b/themes/prism-hopscotch.css
@@ -10,7 +10,7 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	font-family: "Fira Mono", Menlo, Monaco, "Lucida Console", "Courier New", Courier, monospace;
-	font-size: 16px;
+	font-size: 1em;
 	line-height: 1.375;
 	direction: ltr;
 	text-align: left;
@@ -30,10 +30,6 @@ pre[class*="language-"] {
 	word-wrap: break-word;
 	background: #322931;
 	color: #b9b5b8;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 /* Code blocks */

--- a/themes/prism-lucario.css
+++ b/themes/prism-lucario.css
@@ -11,6 +11,7 @@ pre[class*="language-"] {
 	background: none;
 	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
 	font-family: Monaco, Consolas, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-nord.css
+++ b/themes/prism-nord.css
@@ -10,6 +10,7 @@ pre[class*="language-"] {
 	color: #f8f8f2;
 	background: none;
 	font-family: "Fira Code", Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-one-dark.css
+++ b/themes/prism-one-dark.css
@@ -30,6 +30,7 @@ pre[class*="language-"] {
 	color: #abb2bf;
 	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
 	font-family: "Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace;
+	font-size: 1em;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-one-light.css
+++ b/themes/prism-one-light.css
@@ -29,6 +29,7 @@ pre[class*="language-"] {
 	background: #fafafa;
 	color: #383a42;
 	font-family: "Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace;
+	font-size: 1em;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-pojoaque.css
+++ b/themes/prism-pojoaque.css
@@ -19,14 +19,10 @@ pre[class*="language-"] {
 	word-break: break-all;
 	word-wrap: break-word;
 	font-family: Menlo, Monaco, "Courier New", monospace;
-	font-size: 15px;
+	font-size: 1em;
 	line-height: 1.5;
 	color: #dccf8f;
 	text-shadow: 0;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 pre[class*="language-"],
@@ -38,12 +34,12 @@ pre[class*="language-"],
 }
 
 pre[class*="language-"] {
-	padding: 12px;
+	padding: .8em;
 	overflow: auto;
 }
 
 :not(pre) > code[class*="language-"] {
-	padding: 2px 6px;
+	padding: .2em .4em;
 }
 
 .token.namespace {

--- a/themes/prism-shades-of-purple.css
+++ b/themes/prism-shades-of-purple.css
@@ -25,8 +25,8 @@ pre[class*='language-'] {
 
 	font-family: 'Operator Mono', 'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	font-weight: 400;
-	font-size: 17px;
-	line-height: 25px;
+	font-size: 1em;
+	line-height: 1.5;
 	letter-spacing: 0.5px;
 	text-shadow: 0 1px #222245;
 }

--- a/themes/prism-solarized-dark-atom.css
+++ b/themes/prism-solarized-dark-atom.css
@@ -9,6 +9,7 @@ pre[class*="language-"] {
 	color: #839496;
 	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
 	font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
+	font-size: 1em;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-vs.css
+++ b/themes/prism-vs.css
@@ -7,12 +7,12 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: #393A34;
 	font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
+	font-size: 1em;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;
 	word-break: normal;
-	font-size: .9em;
 	line-height: 1.2em;
 
 	-moz-tab-size: 4;
@@ -23,10 +23,6 @@ pre[class*="language-"] {
 	-moz-hyphens: none;
 	-ms-hyphens: none;
 	hyphens: none;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,

--- a/themes/prism-vsc-dark-plus.css
+++ b/themes/prism-vsc-dark-plus.css
@@ -1,9 +1,9 @@
 pre[class*="language-"],
 code[class*="language-"] {
 	color: #d4d4d4;
-	font-size: 13px;
 	text-shadow: none;
 	font-family: Menlo, Monaco, Consolas, "Andale Mono", "Ubuntu Mono", "Courier New", monospace;
+	font-size: 1em;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-xonokai.css
+++ b/themes/prism-xonokai.css
@@ -16,13 +16,9 @@ pre[class*="language-"] {
 	white-space: pre-wrap;
 	word-wrap: normal;
 	font-family: Menlo, Monaco, "Courier New", monospace;
-	font-size: 14px;
+	font-size: 1em;
 	color: #76d9e6;
 	text-shadow: none;
-}
-
-pre > code[class*="language-"] {
-	font-size: 1em;
 }
 
 pre[class*="language-"],
@@ -31,7 +27,7 @@ pre[class*="language-"],
 }
 
 pre[class*="language-"] {
-	padding: 15px;
+	padding: 1em;
 	border-radius: 4px;
 	border: 1px solid #e1e1e8;
 	overflow: auto;

--- a/themes/prism-z-touch.css
+++ b/themes/prism-z-touch.css
@@ -20,9 +20,9 @@ pre[class*="language-"] {
 	-moz-hyphens: none;
 	-ms-hyphens: none;
 	hyphens: none;
-	line-height: 25px;
-	font-size: 18px;
-	margin: 5px 0;
+	line-height: 1.4;
+	font-size: 1em;
+	margin: .3em 0;
 }
 
 pre[class*="language-"] * {
@@ -33,7 +33,7 @@ pre[class*="language-"] * {
 pre[class*="language-"] {
 	color: white;
 	background: #0a143c;
-	padding: 22px;
+	padding: 1.2em;
 }
 
 /* Code blocks */


### PR DESCRIPTION
This PR makes the `font-size` of all themes `1em` (addressing [this comment](https://github.com/PrismJS/prism-themes/issues/137#issuecomment-917689800)). I also adjusted all pixel-based margins and padding that assumed a formerly constant font size.

These changes have one main advantage: Compatibility. We already had bugs there were related to inconsistent font sizes. Making the font size the same for all themes makes it easier to develop plugins.
