### PR TITLE
Increase specificity of selectors for plugin overrides

### DIFF
--- a/themes/prism-base16-ateliersulphurpool.light.css
+++ b/themes/prism-base16-ateliersulphurpool.light.css
@@ -158,18 +158,18 @@ pre > code.highlight {
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
-.line-numbers .line-numbers-rows {
+.line-numbers.line-numbers .line-numbers-rows {
 	border-right-color: #dfe2f1;
 }
 
-.line-numbers-rows > span:before {
+.line-numbers .line-numbers-rows > span:before {
 	color: #979db4;
 }
 
 /* overrides color-values for the Line Highlight plugin
  * http://prismjs.com/plugins/line-highlight/
  */
-.line-highlight {
+.line-highlight.line-highlight {
 	background: rgba(107, 115, 148, 0.2);
 	background: -webkit-linear-gradient(left, rgba(107, 115, 148, 0.2) 70%, rgba(107, 115, 148, 0));
 	background: linear-gradient(to right, rgba(107, 115, 148, 0.2) 70%, rgba(107, 115, 148, 0));

--- a/themes/prism-cb.css
+++ b/themes/prism-cb.css
@@ -125,52 +125,22 @@ pre[class*="language-"] {
 }
 
 /* Line highlight plugin */
-pre[data-line] {
-	position: relative;
-	padding: 1em 0 1em 3em;
-}
-
-.line-highlight {
-	position: absolute;
-	left: 0;
-	right: 0;
-	margin-top: 1em; /* Same as .prism's padding-top */
+.line-highlight.line-highlight {
 	background: rgba(255, 255, 255, .2);
-	pointer-events: none;
-	line-height: inherit;
-	white-space: pre;
 }
 
-.line-highlight:before,
-.line-highlight[data-end]:after {
-	content: attr(data-start);
-	position: absolute;
+.line-highlight.line-highlight:before,
+.line-highlight.line-highlight[data-end]:after {
 	top: .3em;
-	left: .6em;
-	min-width: 1em;
-	padding: 0 .5em;
 	background-color: rgba(255, 255, 255, .3);
 	color: #fff;
-	font: bold 65%/1.5 sans-serif;
-	text-align: center;
 	-moz-border-radius: 8px;
 	-webkit-border-radius: 8px;
 	border-radius: 8px;
-	text-shadow: none;
-}
-
-.line-highlight[data-end]:after {
-	content: attr(data-end);
-	top: auto;
-	bottom: .4em;
 }
 
 /* for line numbers */
-.line-numbers-rows {
-	margin: 0;
-}
-
-.line-numbers-rows span {
-	padding-right: 10px;
+/* span instead of span:before for a two-toned border */
+.line-numbers .line-numbers-rows > span {
 	border-right: 3px #d9d336 solid;
 }

--- a/themes/prism-coldark-cold.css
+++ b/themes/prism-coldark-cold.css
@@ -202,34 +202,34 @@ pre[class*="language-"] {
 /* overrides color-values for the Show Invisibles plugin
  * https://prismjs.com/plugins/show-invisibles/
  */
-.token.tab:not(:empty):before,
-.token.cr:before,
-.token.lf:before,
-.token.space:before {
+.token.token.tab:not(:empty):before,
+.token.token.cr:before,
+.token.token.lf:before,
+.token.token.space:before {
 	color: #3c526d;
 }
 
 /* overrides color-values for the Toolbar plugin
  * https://prismjs.com/plugins/toolbar/
  */
-div.code-toolbar > .toolbar a,
-div.code-toolbar > .toolbar button {
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > a,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > button {
 	color: #e3eaf2;
 	background: #005a8e;
 }
 
-div.code-toolbar > .toolbar a:hover,
-div.code-toolbar > .toolbar a:focus,
-div.code-toolbar > .toolbar button:hover,
-div.code-toolbar > .toolbar button:focus {
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > a:hover,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > a:focus,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > button:hover,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > button:focus {
 	color: #e3eaf2;
 	background: #005a8eda;
 	text-decoration: none;
 }
 
-div.code-toolbar > .toolbar span,
-div.code-toolbar > .toolbar span:hover,
-div.code-toolbar > .toolbar span:focus {
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > span,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > span:hover,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > span:focus {
 	color: #e3eaf2;
 	background: #3c526d;
 }
@@ -237,81 +237,81 @@ div.code-toolbar > .toolbar span:focus {
 /* overrides color-values for the Line Highlight plugin
  * http://prismjs.com/plugins/line-highlight/
  */
-.line-highlight {
+.line-highlight.line-highlight {
 	background: #8da1b92f;
 	background: linear-gradient(to right, #8da1b92f 70%, #8da1b925);
 }
 
-.line-highlight:before,
-.line-highlight[data-end]:after {
+.line-highlight.line-highlight:before,
+.line-highlight.line-highlight[data-end]:after {
 	background-color: #3c526d;
 	color: #e3eaf2;
 	box-shadow: 0 1px #8da1b9;
 }
 
-pre[id].linkable-line-numbers span.line-numbers-rows > span:hover:before {
+pre[id].linkable-line-numbers.linkable-line-numbers span.line-numbers-rows > span:hover:before {
 	background-color: #3c526d1f;
 }
 
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
-.line-numbers .line-numbers-rows {
+.line-numbers.line-numbers .line-numbers-rows {
 	border-right: 1px solid #8da1b97a;
 	background: #d0dae77a;
 }
 
-.line-numbers-rows > span:before {
+.line-numbers .line-numbers-rows > span:before {
 	color: #3c526dda;
 }
 
 /* overrides color-values for the Match Braces plugin
  * https://prismjs.com/plugins/match-braces/
  */
-.rainbow-braces .token.punctuation.brace-level-1,
-.rainbow-braces .token.punctuation.brace-level-5,
-.rainbow-braces .token.punctuation.brace-level-9 {
+.rainbow-braces .token.token.punctuation.brace-level-1,
+.rainbow-braces .token.token.punctuation.brace-level-5,
+.rainbow-braces .token.token.punctuation.brace-level-9 {
 	color: #755f00;
 }
 
-.rainbow-braces .token.punctuation.brace-level-2,
-.rainbow-braces .token.punctuation.brace-level-6,
-.rainbow-braces .token.punctuation.brace-level-10 {
+.rainbow-braces .token.token.punctuation.brace-level-2,
+.rainbow-braces .token.token.punctuation.brace-level-6,
+.rainbow-braces .token.token.punctuation.brace-level-10 {
 	color: #af00af;
 }
 
-.rainbow-braces .token.punctuation.brace-level-3,
-.rainbow-braces .token.punctuation.brace-level-7,
-.rainbow-braces .token.punctuation.brace-level-11 {
+.rainbow-braces .token.token.punctuation.brace-level-3,
+.rainbow-braces .token.token.punctuation.brace-level-7,
+.rainbow-braces .token.token.punctuation.brace-level-11 {
 	color: #005a8e;
 }
 
-.rainbow-braces .token.punctuation.brace-level-4,
-.rainbow-braces .token.punctuation.brace-level-8,
-.rainbow-braces .token.punctuation.brace-level-12 {
+.rainbow-braces .token.token.punctuation.brace-level-4,
+.rainbow-braces .token.token.punctuation.brace-level-8,
+.rainbow-braces .token.token.punctuation.brace-level-12 {
 	color: #7c00aa;
 }
 
 /* overrides color-values for the Diff Highlight plugin
  * https://prismjs.com/plugins/diff-highlight/
  */
-pre.diff-highlight > code .token.deleted:not(.prefix),
-pre > code.diff-highlight .token.deleted:not(.prefix) {
+pre.diff-highlight > code .token.token.deleted:not(.prefix),
+pre > code.diff-highlight .token.token.deleted:not(.prefix) {
 	background-color: #c22f2e1f;
 }
 
-pre.diff-highlight > code .token.inserted:not(.prefix),
-pre > code.diff-highlight .token.inserted:not(.prefix) {
+pre.diff-highlight > code .token.token.inserted:not(.prefix),
+pre > code.diff-highlight .token.token.inserted:not(.prefix) {
 	background-color: #116b001f;
 }
 
 /* overrides color-values for the Command Line plugin
  * https://prismjs.com/plugins/command-line/
  */
-.command-line-prompt {
+.command-line .command-line-prompt {
 	border-right: 1px solid #8da1b97a;
 }
 
-.command-line-prompt > span:before {
+.command-line .command-line-prompt > span:before {
 	color: #3c526dda;
 }

--- a/themes/prism-coldark-dark.css
+++ b/themes/prism-coldark-dark.css
@@ -202,34 +202,34 @@ pre[class*="language-"] {
 /* overrides color-values for the Show Invisibles plugin
  * https://prismjs.com/plugins/show-invisibles/
  */
-.token.tab:not(:empty):before,
-.token.cr:before,
-.token.lf:before,
-.token.space:before {
+.token.token.tab:not(:empty):before,
+.token.token.cr:before,
+.token.token.lf:before,
+.token.token.space:before {
 	color: #8da1b9;
 }
 
 /* overrides color-values for the Toolbar plugin
  * https://prismjs.com/plugins/toolbar/
  */
-div.code-toolbar > .toolbar a,
-div.code-toolbar > .toolbar button {
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > a,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > button {
 	color: #111b27;
 	background: #6cb8e6;
 }
 
-div.code-toolbar > .toolbar a:hover,
-div.code-toolbar > .toolbar a:focus,
-div.code-toolbar > .toolbar button:hover,
-div.code-toolbar > .toolbar button:focus {
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > a:hover,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > a:focus,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > button:hover,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > button:focus {
 	color: #111b27;
 	background: #6cb8e6da;
 	text-decoration: none;
 }
 
-div.code-toolbar > .toolbar span,
-div.code-toolbar > .toolbar span:hover,
-div.code-toolbar > .toolbar span:focus {
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > span,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > span:hover,
+div.code-toolbar > .toolbar.toolbar > .toolbar-item > span:focus {
 	color: #111b27;
 	background: #8da1b9;
 }
@@ -237,81 +237,81 @@ div.code-toolbar > .toolbar span:focus {
 /* overrides color-values for the Line Highlight plugin
  * http://prismjs.com/plugins/line-highlight/
  */
-.line-highlight {
+.line-highlight.line-highlight {
 	background: #3c526d5f;
 	background: linear-gradient(to right, #3c526d5f 70%, #3c526d55);
 }
 
-.line-highlight:before,
-.line-highlight[data-end]:after {
+.line-highlight.line-highlight:before,
+.line-highlight.line-highlight[data-end]:after {
 	background-color: #8da1b9;
 	color: #111b27;
 	box-shadow: 0 1px #3c526d;
 }
 
-pre[id].linkable-line-numbers span.line-numbers-rows > span:hover:before {
+pre[id].linkable-line-numbers.linkable-line-numbers span.line-numbers-rows > span:hover:before {
 	background-color: #8da1b918;
 }
 
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
-.line-numbers .line-numbers-rows {
+.line-numbers.line-numbers .line-numbers-rows {
 	border-right: 1px solid #0b121b;
 	background: #0b121b7a;
 }
 
-.line-numbers-rows > span:before {
+.line-numbers .line-numbers-rows > span:before {
 	color: #8da1b9da;
 }
 
 /* overrides color-values for the Match Braces plugin
  * https://prismjs.com/plugins/match-braces/
  */
-.rainbow-braces .token.punctuation.brace-level-1,
-.rainbow-braces .token.punctuation.brace-level-5,
-.rainbow-braces .token.punctuation.brace-level-9 {
+.rainbow-braces .token.token.punctuation.brace-level-1,
+.rainbow-braces .token.token.punctuation.brace-level-5,
+.rainbow-braces .token.token.punctuation.brace-level-9 {
 	color: #e6d37a;
 }
 
-.rainbow-braces .token.punctuation.brace-level-2,
-.rainbow-braces .token.punctuation.brace-level-6,
-.rainbow-braces .token.punctuation.brace-level-10 {
+.rainbow-braces .token.token.punctuation.brace-level-2,
+.rainbow-braces .token.token.punctuation.brace-level-6,
+.rainbow-braces .token.token.punctuation.brace-level-10 {
 	color: #f4adf4;
 }
 
-.rainbow-braces .token.punctuation.brace-level-3,
-.rainbow-braces .token.punctuation.brace-level-7,
-.rainbow-braces .token.punctuation.brace-level-11 {
+.rainbow-braces .token.token.punctuation.brace-level-3,
+.rainbow-braces .token.token.punctuation.brace-level-7,
+.rainbow-braces .token.token.punctuation.brace-level-11 {
 	color: #6cb8e6;
 }
 
-.rainbow-braces .token.punctuation.brace-level-4,
-.rainbow-braces .token.punctuation.brace-level-8,
-.rainbow-braces .token.punctuation.brace-level-12 {
+.rainbow-braces .token.token.punctuation.brace-level-4,
+.rainbow-braces .token.token.punctuation.brace-level-8,
+.rainbow-braces .token.token.punctuation.brace-level-12 {
 	color: #c699e3;
 }
 
 /* overrides color-values for the Diff Highlight plugin
  * https://prismjs.com/plugins/diff-highlight/
  */
-pre.diff-highlight > code .token.deleted:not(.prefix),
-pre > code.diff-highlight .token.deleted:not(.prefix) {
+pre.diff-highlight > code .token.token.deleted:not(.prefix),
+pre > code.diff-highlight .token.token.deleted:not(.prefix) {
 	background-color: #cd66601f;
 }
 
-pre.diff-highlight > code .token.inserted:not(.prefix),
-pre > code.diff-highlight .token.inserted:not(.prefix) {
+pre.diff-highlight > code .token.token.inserted:not(.prefix),
+pre > code.diff-highlight .token.token.inserted:not(.prefix) {
 	background-color: #91d0761f;
 }
 
 /* overrides color-values for the Command Line plugin
  * https://prismjs.com/plugins/command-line/
  */
-.command-line-prompt {
+.command-line .command-line-prompt {
 	border-right: 1px solid #0b121b;
 }
 
-.command-line-prompt > span:before {
+.command-line .command-line-prompt > span:before {
 	color: #8da1b9da;
 }

--- a/themes/prism-duotone-dark.css
+++ b/themes/prism-duotone-dark.css
@@ -154,18 +154,18 @@ pre > code.highlight {
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
-.line-numbers .line-numbers-rows {
+.line-numbers.line-numbers .line-numbers-rows {
 	border-right-color: #2c2937;
 }
 
-.line-numbers-rows > span:before {
+.line-numbers .line-numbers-rows > span:before {
 	color: #3c3949;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
-.line-highlight {
+.line-highlight.line-highlight {
 	background: rgba(224, 145, 66, 0.2);
 	background: -webkit-linear-gradient(left, rgba(224, 145, 66, 0.2) 70%, rgba(224, 145, 66, 0));
 	background: linear-gradient(to right, rgba(224, 145, 66, 0.2) 70%, rgba(224, 145, 66, 0));

--- a/themes/prism-duotone-earth.css
+++ b/themes/prism-duotone-earth.css
@@ -154,18 +154,18 @@ pre > code.highlight {
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
-.line-numbers .line-numbers-rows {
+.line-numbers.line-numbers .line-numbers-rows {
 	border-right-color: #35302b;
 }
 
-.line-numbers-rows > span:before {
+.line-numbers .line-numbers-rows > span:before {
 	color: #46403d;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
-.line-highlight {
+.line-highlight.line-highlight {
 	background: rgba(191, 160, 90, 0.2);
 	background: -webkit-linear-gradient(left, rgba(191, 160, 90, 0.2) 70%, rgba(191, 160, 90, 0));
 	background: linear-gradient(to right, rgba(191, 160, 90, 0.2) 70%, rgba(191, 160, 90, 0));

--- a/themes/prism-duotone-forest.css
+++ b/themes/prism-duotone-forest.css
@@ -154,18 +154,18 @@ pre > code.highlight {
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
-.line-numbers .line-numbers-rows {
+.line-numbers.line-numbers .line-numbers-rows {
 	border-right-color: #2c302c;
 }
 
-.line-numbers-rows > span:before {
+.line-numbers .line-numbers-rows > span:before {
 	color: #3b423b;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
-.line-highlight {
+.line-highlight.line-highlight {
 	background: rgba(162, 179, 77, 0.2);
 	background: -webkit-linear-gradient(left, rgba(162, 179, 77, 0.2) 70%, rgba(162, 179, 77, 0));
 	background: linear-gradient(to right, rgba(162, 179, 77, 0.2) 70%, rgba(162, 179, 77, 0));

--- a/themes/prism-duotone-light.css
+++ b/themes/prism-duotone-light.css
@@ -154,18 +154,18 @@ pre > code.highlight {
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
-.line-numbers .line-numbers-rows {
+.line-numbers.line-numbers .line-numbers-rows {
 	border-right-color: #ece8de;
 }
 
-.line-numbers-rows > span:before {
+.line-numbers .line-numbers-rows > span:before {
 	color: #cdc4b1;
 }
 
 /* overrides color-values for the Line Highlight plugin
  * http://prismjs.com/plugins/line-highlight/
  */
-.line-highlight {
+.line-highlight.line-highlight {
 	background: rgba(45, 32, 6, 0.2);
 	background: -webkit-linear-gradient(left, rgba(45, 32, 6, 0.2) 70%, rgba(45, 32, 6, 0));
 	background: linear-gradient(to right, rgba(45, 32, 6, 0.2) 70%, rgba(45, 32, 6, 0));

--- a/themes/prism-duotone-sea.css
+++ b/themes/prism-duotone-sea.css
@@ -154,18 +154,18 @@ pre > code.highlight {
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
-.line-numbers .line-numbers-rows {
+.line-numbers.line-numbers .line-numbers-rows {
 	border-right-color: #1f2932;
 }
 
-.line-numbers-rows > span:before {
+.line-numbers .line-numbers-rows > span:before {
 	color: #2c3847;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
-.line-highlight {
+.line-highlight.line-highlight {
 	background: rgba(10, 163, 112, 0.2);
 	background: -webkit-linear-gradient(left, rgba(10, 163, 112, 0.2) 70%, rgba(10, 163, 112, 0));
 	background: linear-gradient(to right, rgba(10, 163, 112, 0.2) 70%, rgba(10, 163, 112, 0));

--- a/themes/prism-duotone-space.css
+++ b/themes/prism-duotone-space.css
@@ -154,18 +154,18 @@ pre > code.highlight {
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
-.line-numbers .line-numbers-rows {
+.line-numbers.line-numbers .line-numbers-rows {
 	border-right-color: #262631;
 }
 
-.line-numbers-rows > span:before {
+.line-numbers .line-numbers-rows > span:before {
 	color: #393949;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
-.line-highlight {
+.line-highlight.line-highlight {
 	background: rgba(221, 103, 44, 0.2);
 	background: -webkit-linear-gradient(left, rgba(221, 103, 44, 0.2) 70%, rgba(221, 103, 44, 0));
 	background: linear-gradient(to right, rgba(221, 103, 44, 0.2) 70%, rgba(221, 103, 44, 0));

--- a/themes/prism-shades-of-purple.css
+++ b/themes/prism-shades-of-purple.css
@@ -190,9 +190,7 @@ code.language-css .token.selector > .token.pseudo-element {
 	background: linear-gradient(to right, rgba(179, 98, 255, 0.17), transparent);
 }
 
-pre .line-highlight:before,
-pre > code.line-highlight:before,
-pre .line-highlight[data-end]:after,
-pre > code.line-highlight[data-end]:after {
+.line-highlight.line-highlight:before,
+.line-highlight.line-highlight[data-end]:after {
 	content: '';
 }

--- a/themes/prism-shades-of-purple.css
+++ b/themes/prism-shades-of-purple.css
@@ -185,9 +185,7 @@ code.language-css .token.selector > .token.pseudo-element {
 	background: none;
 }
 
-pre .line-highlight,
-pre .line-highlight.line-highlight,
-pre > code.line-highlight {
+.line-highlight.line-highlight {
 	margin-top: 36px;
 	background: linear-gradient(to right, rgba(179, 98, 255, 0.17), transparent);
 }

--- a/themes/prism-vs.css
+++ b/themes/prism-vs.css
@@ -150,18 +150,18 @@ code[class*="language-css"] {
 /* overrides color-values for the Line Numbers plugin
  * http://prismjs.com/plugins/line-numbers/
  */
-.line-numbers .line-numbers-rows {
+.line-numbers.line-numbers .line-numbers-rows {
 	border-right-color: #a5a5a5;
 }
 
-.line-numbers-rows > span:before {
+.line-numbers .line-numbers-rows > span:before {
 	color: #2B91AF;
 }
 
 /* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 */
-.line-highlight {
+.line-highlight.line-highlight {
 	background: rgba(193, 222, 241, 0.2);
 	background: -webkit-linear-gradient(left, rgba(193, 222, 241, 0.2) 70%, rgba(221, 222, 241, 0));
 	background: linear-gradient(to right, rgba(193, 222, 241, 0.2) 70%, rgba(221, 222, 241, 0));

--- a/themes/prism-vsc-dark-plus.css
+++ b/themes/prism-vsc-dark-plus.css
@@ -263,25 +263,13 @@ code[class*="language-html"] {
 /*********************************************************
 * Line highlighting
 */
-pre[data-line] {
-	position: relative;
-}
-
 pre[class*="language-"] > code[class*="language-"] {
 	position: relative;
 	z-index: 1;
 }
 
 .line-highlight.line-highlight {
-	position: absolute;
-	left: 0;
-	right: 0;
-	padding: inherit 0;
-	margin-top: 1em;
 	background: #f7ebc6;
 	box-shadow: inset 5px 0 0 #f7d87c;
 	z-index: 0;
-	pointer-events: none;
-	line-height: inherit;
-	white-space: pre;
 }

--- a/themes/prism-vsc-dark-plus.css
+++ b/themes/prism-vsc-dark-plus.css
@@ -272,7 +272,7 @@ pre[class*="language-"] > code[class*="language-"] {
 	z-index: 1;
 }
 
-.line-highlight {
+.line-highlight.line-highlight {
 	position: absolute;
 	left: 0;
 	right: 0;

--- a/themes/prism-xonokai.css
+++ b/themes/prism-xonokai.css
@@ -146,13 +146,13 @@ code.language-markup .token.script .token.keyword {
 }
 
 /* Line highlight plugin */
-pre[data-line] .line-highlight {
+.line-highlight.line-highlight {
 	padding: 0;
 	background: rgba(255, 255, 255, 0.08);
 }
 
-pre[data-line] .line-highlight:before,
-pre[data-line] .line-highlight[data-end]:after {
+.line-highlight.line-highlight:before,
+.line-highlight.line-highlight[data-end]:after {
 	padding: 0.2em 0.5em;
 	background-color: rgba(255, 255, 255, 0.4);
 	color: black;

--- a/themes/prism-xonokai.css
+++ b/themes/prism-xonokai.css
@@ -146,44 +146,17 @@ code.language-markup .token.script .token.keyword {
 }
 
 /* Line highlight plugin */
-pre[class*="language-"][data-line] {
-	position: relative;
-	padding: 1em 0 1em 3em;
-}
-
 pre[data-line] .line-highlight {
-	position: absolute;
-	left: 0;
-	right: 0;
 	padding: 0;
-	margin-top: 1em;
 	background: rgba(255, 255, 255, 0.08);
-	pointer-events: none;
-	line-height: inherit;
-	white-space: pre;
 }
 
 pre[data-line] .line-highlight:before,
 pre[data-line] .line-highlight[data-end]:after {
-	content: attr(data-start);
-	position: absolute;
-	top: .4em;
-	left: .6em;
-	min-width: 1em;
 	padding: 0.2em 0.5em;
 	background-color: rgba(255, 255, 255, 0.4);
 	color: black;
-	font: bold 65%/1 sans-serif;
 	height: 1em;
 	line-height: 1em;
-	text-align: center;
-	border-radius: 999px;
-	text-shadow: none;
 	box-shadow: 0 1px 1px rgba(255, 255, 255, 0.7);
-}
-
-pre[data-line] .line-highlight[data-end]:after {
-	content: attr(data-end);
-	top: auto;
-	bottom: .4em;
 }


### PR DESCRIPTION
<!--
🙌 Thank you for making this PR!
Before submitting your PR, please check the following:
- Your code follows the code style of this project (`npm run lint`).
- You have performed a self-review of your own code.
- You have run the test cases (`npm run test`).
-->

This PR came about as a result of [this comment](https://github.com/PrismJS/prism-themes/pull/134#discussion_r707657531), which pointed out that we do not necessarily have control over the ordering of stylesheets, and hence selectors for plugin overrides need to have higher specificity values than the those in the plugins' default stylesheets.

I need to play around with this section further because I don't yet know what it does:
https://github.com/PrismJS/prism-themes/blob/e6cf98987533b64f51bdbc0c902861b46e14c96c/themes/prism-cb.css#L168-L176