### PR TITLE
Don't lint minified files

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -10,5 +10,8 @@
 		"number-leading-zero": null,
 		"selector-list-comma-newline-after": null,
 		"selector-pseudo-element-colon-notation": "single"
-	}
+	},
+	"ignoreFiles": [
+		"**/*.min.css"
+	]
 }


### PR DESCRIPTION
While doing some testing, I noticed that our lint command `npm run lint` also lints minified files. This PR puts an end to that.